### PR TITLE
Add svag for SVG optimization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -960,7 +960,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f6597e8bdbca37f1f56e5a80d15857b0932aead21a78d20de49e99e74933046"
 dependencies = [
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
 ]
 
@@ -1715,6 +1715,7 @@ dependencies = [
  "scraper",
  "serde",
  "shellexpand",
+ "svag",
  "syntect",
  "thiserror 2.0.17",
  "thumbhash",
@@ -5760,7 +5761,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.12.1",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -5977,6 +5978,15 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quick-xml"
@@ -7285,6 +7295,17 @@ name = "supports-unicode"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
+
+[[package]]
+name = "svag"
+version = "0.1.1"
+source = "git+https://github.com/bearcove/svag#7fa4d99b1ccf399560a27df8fa28d99805eede68"
+dependencies = [
+ "clap",
+ "quick-xml 0.37.5",
+ "ryu",
+ "thiserror 2.0.17",
+]
 
 [[package]]
 name = "svgtypes"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,9 @@ thumbhash = "0.1"  # Compact image placeholders (~28 bytes)
 # HTML minification
 minify-html = "0.18"
 
+# SVG optimization
+svag = { git = "https://github.com/bearcove/svag" }
+
 # Minimal-versions workarounds: these transitive deps have ancient minimum
 # version specs that don't build on modern Rust
 phf = "0.11"  # 0.11+ drops proc-macro-hack (which needs syn 0.15)


### PR DESCRIPTION
## Summary

Integrates [svag](https://github.com/bearcove/svag) for proper SVG minification.

### Changes
- Replace passthrough `optimize_svg` with svag minifier
- Removes comments, metadata, and unnecessary whitespace
- Optimizes path data and colors (`#ff0000` → `red`)
- **Preserves case-sensitive attributes** like `viewBox` (unlike minify-html which broke SVGs)

### Before
SVGs were passed through unchanged due to minify-html lowercasing attributes.

### After
SVGs are properly optimized while maintaining correctness.