### PR TITLE
Plugin system + website restructure

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,0 @@
-[target.x86_64-unknown-linux-gnu]
-linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=mold"]
-
-[target.aarch64-unknown-linux-gnu]
-linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=mold"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1862,6 +1862,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dodeca-baseline"
+version = "0.1.0"
+dependencies = [
+ "linkme",
+ "plugcard",
+ "postcard-schema",
+]
+
+[[package]]
 name = "dragonbox_ecma"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4104,6 +4113,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
+name = "linkme"
+version = "0.3.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e3283ed2d0e50c06dd8602e0ab319bb048b6325d0bba739db64ed8205179898"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5cec0ec4228b4853bb129c84dbf093a27e6c7a20526da046defc334a1b017f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6031,6 +6060,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "plugcard"
+version = "0.1.0"
+dependencies = [
+ "linkme",
+ "plugcard-macros",
+ "postcard",
+ "postcard-schema",
+ "serde",
+]
+
+[[package]]
+name = "plugcard-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unsynn",
+]
+
+[[package]]
 name = "png"
 version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6090,6 +6139,27 @@ dependencies = [
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
  "heapless",
+ "serde",
+]
+
+[[package]]
+name = "postcard-derive"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0232bd009a197ceec9cc881ba46f727fcd8060a2d8d6a9dde7a69030a6fe2bb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "postcard-schema"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a3e7acbdb61449280eb8c54126ecfb10571ec06add5c60d014c675f029e7d2"
+dependencies = [
+ "postcard-derive",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "crates/livereload-client", "xtask"]
+members = [".", "crates/livereload-client", "crates/plugcard", "crates/plugcard-macros", "crates/dodeca-baseline", "xtask"]
 
 [package]
 name = "dodeca"

--- a/benches/html_diff.rs
+++ b/benches/html_diff.rs
@@ -263,17 +263,13 @@ fn diff_one_change_medium(bencher: Bencher) {
     let mut new = generate_large_page(20, 10);
 
     // Modify one paragraph
-    if let Some(main) = new.children.get_mut(2) {
-        if let Some(article) = main.children.get_mut(0) {
-            if let Some(section) = article.children.get_mut(10) {
-                if let Some(para) = section.children.get_mut(3) {
-                    if let Some(text_node) = para.children.get_mut(0) {
+    if let Some(main) = new.children.get_mut(2)
+        && let Some(article) = main.children.get_mut(0)
+            && let Some(section) = article.children.get_mut(10)
+                && let Some(para) = section.children.get_mut(3)
+                    && let Some(text_node) = para.children.get_mut(0) {
                         text_node.text = "THIS TEXT WAS CHANGED!".to_string();
                     }
-                }
-            }
-        }
-    }
 
     old.compute_hashes_parallel();
     new.compute_hashes_parallel();
@@ -287,17 +283,13 @@ fn diff_one_change_large(bencher: Bencher) {
     let mut new = generate_large_page(50, 20);
 
     // Modify one paragraph deep in the tree
-    if let Some(main) = new.children.get_mut(2) {
-        if let Some(article) = main.children.get_mut(0) {
-            if let Some(section) = article.children.get_mut(25) {
-                if let Some(para) = section.children.get_mut(5) {
-                    if let Some(text_node) = para.children.get_mut(0) {
+    if let Some(main) = new.children.get_mut(2)
+        && let Some(article) = main.children.get_mut(0)
+            && let Some(section) = article.children.get_mut(25)
+                && let Some(para) = section.children.get_mut(5)
+                    && let Some(text_node) = para.children.get_mut(0) {
                         text_node.text = "THIS TEXT WAS CHANGED!".to_string();
                     }
-                }
-            }
-        }
-    }
 
     old.compute_hashes_parallel();
     new.compute_hashes_parallel();
@@ -312,17 +304,13 @@ fn diff_many_changes_medium(bencher: Bencher) {
 
     // Modify several paragraphs across different sections
     for section_idx in [2, 5, 10, 15, 18] {
-        if let Some(main) = new.children.get_mut(2) {
-            if let Some(article) = main.children.get_mut(0) {
-                if let Some(section) = article.children.get_mut(section_idx) {
-                    if let Some(para) = section.children.get_mut(1) {
-                        if let Some(text_node) = para.children.get_mut(0) {
+        if let Some(main) = new.children.get_mut(2)
+            && let Some(article) = main.children.get_mut(0)
+                && let Some(section) = article.children.get_mut(section_idx)
+                    && let Some(para) = section.children.get_mut(1)
+                        && let Some(text_node) = para.children.get_mut(0) {
                             text_node.text = format!("CHANGED section {}", section_idx);
                         }
-                    }
-                }
-            }
-        }
     }
 
     old.compute_hashes_parallel();

--- a/crates/dodeca-baseline/Cargo.toml
+++ b/crates/dodeca-baseline/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "dodeca-baseline"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.85"
+description = "Baseline plugin for dodeca - simple transforms for testing"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+plugcard = { path = "../plugcard" }
+# Needed directly because proc-macro derives reference their crates by name
+linkme = "0.3"
+postcard-schema = { version = "0.1", features = ["derive", "alloc"] }

--- a/crates/dodeca-baseline/src/lib.rs
+++ b/crates/dodeca-baseline/src/lib.rs
@@ -1,0 +1,98 @@
+//! Dodeca baseline plugin - simple transforms for testing the plugin system
+
+use plugcard::plugcard;
+
+/// Reverse a string
+#[plugcard]
+pub fn reverse_string(input: String) -> String {
+    input.chars().rev().collect()
+}
+
+/// Add two numbers
+#[plugcard]
+pub fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+#[cfg(test)]
+mod tests {
+    use plugcard::{list_methods, MethodCallData, MethodCallResult};
+
+    #[test]
+    fn test_methods_registered() {
+        let methods = list_methods();
+        assert!(methods.len() >= 2, "Expected at least 2 methods, got {}", methods.len());
+
+        let names: Vec<_> = methods.iter().map(|m| m.name).collect();
+        assert!(names.contains(&"reverse_string"), "Missing reverse_string");
+        assert!(names.contains(&"add"), "Missing add");
+    }
+
+    #[test]
+    fn test_reverse_string_dispatch() {
+        let methods = list_methods();
+        let reverse = methods.iter().find(|m| m.name == "reverse_string").unwrap();
+
+        // Serialize input: { input: "hello" }
+        #[derive(plugcard::serde::Serialize)]
+        #[serde(crate = "plugcard::serde")]
+        struct Input { input: String }
+
+        let input = Input { input: "hello".to_string() };
+        let input_bytes = plugcard::postcard::to_allocvec(&input).unwrap();
+
+        let mut output_buf = [0u8; 256];
+        let mut data = MethodCallData {
+            key: reverse.key,
+            input_ptr: input_bytes.as_ptr(),
+            input_len: input_bytes.len(),
+            output_ptr: output_buf.as_mut_ptr(),
+            output_cap: output_buf.len(),
+            output_len: 0,
+            result: MethodCallResult::default(),
+        };
+
+        // Call the method
+        unsafe { (reverse.call)(&mut data) };
+
+        assert_eq!(data.result, MethodCallResult::Success);
+
+        // Deserialize output
+        let output: String = plugcard::postcard::from_bytes(&output_buf[..data.output_len]).unwrap();
+        assert_eq!(output, "olleh");
+    }
+
+    #[test]
+    fn test_add_dispatch() {
+        let methods = list_methods();
+        let add_method = methods.iter().find(|m| m.name == "add").unwrap();
+
+        // Serialize input: { a: 2, b: 3 }
+        #[derive(plugcard::serde::Serialize)]
+        #[serde(crate = "plugcard::serde")]
+        struct Input { a: i32, b: i32 }
+
+        let input = Input { a: 2, b: 3 };
+        let input_bytes = plugcard::postcard::to_allocvec(&input).unwrap();
+
+        let mut output_buf = [0u8; 256];
+        let mut data = MethodCallData {
+            key: add_method.key,
+            input_ptr: input_bytes.as_ptr(),
+            input_len: input_bytes.len(),
+            output_ptr: output_buf.as_mut_ptr(),
+            output_cap: output_buf.len(),
+            output_len: 0,
+            result: MethodCallResult::default(),
+        };
+
+        // Call the method
+        unsafe { (add_method.call)(&mut data) };
+
+        assert_eq!(data.result, MethodCallResult::Success);
+
+        // Deserialize output
+        let output: i32 = plugcard::postcard::from_bytes(&output_buf[..data.output_len]).unwrap();
+        assert_eq!(output, 5);
+    }
+}

--- a/crates/livereload-client/Cargo.toml
+++ b/crates/livereload-client/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 rust-version = "1.91"
 description = "WASM client for dodeca live reload - applies DOM patches"
+publish = false
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/crates/plugcard-macros/Cargo.toml
+++ b/crates/plugcard-macros/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "plugcard-macros"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.85"
+description = "Proc macros for plugcard plugin system"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[lib]
+proc-macro = true
+
+[dependencies]
+unsynn = "0.3"
+proc-macro2 = "1"
+quote = "1"

--- a/crates/plugcard-macros/src/lib.rs
+++ b/crates/plugcard-macros/src/lib.rs
@@ -1,0 +1,227 @@
+//! Proc macros for plugcard plugin system
+//!
+//! Provides the `#[plugcard]` attribute macro for exposing functions as plugin methods.
+
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use unsynn::*;
+
+// ============================================================================
+// GRAMMAR DEFINITIONS (private to this crate)
+// ============================================================================
+
+keyword! {
+    KFn = "fn"
+}
+keyword! {
+    KPub = "pub"
+}
+keyword! {
+    KCrate = "crate"
+}
+keyword! {
+    KIn = "in"
+}
+
+operator! {
+    RArrow = "->"
+}
+operator! {
+    HashSign = "#"
+}
+
+type ModPath = Cons<Option<PathSep>, PathSepDelimited<Ident>>;
+type VerbatimUntil<C> = Many<Cons<Except<C>, TokenTree>>;
+
+// Outer attribute: #[...]
+unsynn! {
+    struct OuterAttr {
+        _hash: HashSign,
+        _content: BracketGroup,
+    }
+
+    enum Vis {
+        PubIn(Cons<KPub, ParenthesisGroupContaining<Cons<Option<KIn>, ModPath>>>),
+        Pub(KPub),
+    }
+
+    struct FnArg {
+        name: Ident,
+        _colon: Colon,
+        ty: VerbatimUntil<Comma>,
+    }
+
+    struct ReturnType {
+        _arrow: RArrow,
+        ty: VerbatimUntil<BraceGroup>,
+    }
+
+    struct Function {
+        attrs: Vec<OuterAttr>,
+        vis: Option<Vis>,
+        _fn: KFn,
+        name: Ident,
+        args: ParenthesisGroupContaining<CommaDelimitedVec<FnArg>>,
+        ret: Option<ReturnType>,
+        body: BraceGroup,
+    }
+}
+
+// ============================================================================
+// MACRO IMPLEMENTATION
+// ============================================================================
+
+/// Mark a function as a plugcard method
+///
+/// The function must have arguments and return type that implement
+/// `Serialize`, `Deserialize`, and `Schema`.
+///
+/// # Example
+/// ```ignore
+/// #[plugcard]
+/// pub fn add(a: i32, b: i32) -> i32 {
+///     a + b
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn plugcard(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let item2: proc_macro2::TokenStream = item.clone().into();
+
+    match plugcard_impl(item2.clone()) {
+        Ok(output) => output.into(),
+        Err(err) => {
+            let err_msg = err.to_string();
+            quote! {
+                compile_error!(#err_msg);
+                #item2
+            }
+            .into()
+        }
+    }
+}
+
+fn plugcard_impl(item: proc_macro2::TokenStream) -> std::result::Result<proc_macro2::TokenStream, String> {
+    // Parse the function
+    let mut iter = item.clone().to_token_iter();
+    let func: Cons<Function, EndOfStream> = iter
+        .parse()
+        .map_err(|e| format!("Failed to parse function: {e}"))?;
+    let func = func.first;
+
+    let fn_name = &func.name;
+    let fn_body = func.body.to_token_stream();
+
+    // Extract arguments
+    let args: Vec<_> = func
+        .args
+        .content
+        .iter()
+        .map(|d| {
+            let arg = &d.value;
+            let name = &arg.name;
+            // Collect type tokens
+            let ty_tokens: proc_macro2::TokenStream = arg
+                .ty
+                .iter()
+                .map(|t| t.value.second.clone())
+                .collect();
+            (name.clone(), ty_tokens)
+        })
+        .collect();
+
+    // Extract return type
+    let return_type: proc_macro2::TokenStream = if let Some(ret) = &func.ret {
+        ret.ty.iter().map(|t| t.value.second.clone()).collect()
+    } else {
+        quote! { () }
+    };
+
+    // Generate names
+    let wrapper_name = format_ident!("__plugcard_wrapper_{}", fn_name);
+    let input_type_name = format_ident!("__PlugcardInput_{}", fn_name);
+    let sig_name = format_ident!("__PLUGCARD_SIG_{}", fn_name);
+    let method_name_str = fn_name.to_string();
+
+    // Generate input struct fields
+    let input_fields: Vec<_> = args
+        .iter()
+        .map(|(name, ty)| {
+            quote! { pub #name: #ty }
+        })
+        .collect();
+
+    // Generate argument list for original function
+    let arg_names: Vec<_> = args.iter().map(|(name, _)| name.clone()).collect();
+    let arg_types: Vec<_> = args.iter().map(|(_, ty)| ty.clone()).collect();
+
+    // Generate visibility
+    let vis = if func.vis.is_some() {
+        quote! { pub }
+    } else {
+        quote! {}
+    };
+
+    let output = quote! {
+        // Original function (unchanged)
+        #vis fn #fn_name(#(#arg_names: #arg_types),*) -> #return_type
+        #fn_body
+
+        // Input composite type
+        #[derive(::plugcard::serde::Serialize, ::plugcard::serde::Deserialize, ::plugcard::postcard_schema::Schema)]
+        #[serde(crate = "::plugcard::serde")]
+        #[allow(non_camel_case_types)]
+        struct #input_type_name {
+            #(#input_fields),*
+        }
+
+        // C-compatible wrapper
+        #[allow(non_snake_case)]
+        unsafe extern "C" fn #wrapper_name(data: *mut ::plugcard::MethodCallData) {
+            unsafe {
+                let data = &mut *data;
+
+                // Deserialize input
+                let input_slice = ::core::slice::from_raw_parts(data.input_ptr, data.input_len);
+                let input: #input_type_name = match ::plugcard::postcard::from_bytes(input_slice) {
+                    Ok(v) => v,
+                    Err(_) => {
+                        data.result = ::plugcard::MethodCallResult::DeserializeError;
+                        return;
+                    }
+                };
+
+                // Call the actual function
+                let result = #fn_name(#(input.#arg_names),*);
+
+                // Serialize output
+                let output_slice = ::core::slice::from_raw_parts_mut(data.output_ptr, data.output_cap);
+                match ::plugcard::postcard::to_slice(&result, output_slice) {
+                    Ok(written) => {
+                        data.output_len = written.len();
+                        data.result = ::plugcard::MethodCallResult::Success;
+                    }
+                    Err(_) => {
+                        data.result = ::plugcard::MethodCallResult::SerializeError;
+                    }
+                }
+            }
+        }
+
+        // Register in distributed slice
+        #[::plugcard::linkme::distributed_slice(::plugcard::METHODS)]
+        #[allow(non_upper_case_globals)]
+        static #sig_name: ::plugcard::MethodSignature = ::plugcard::MethodSignature {
+            key: ::plugcard::compute_key(
+                #method_name_str,
+                <#input_type_name as ::plugcard::postcard_schema::Schema>::SCHEMA,
+                <#return_type as ::plugcard::postcard_schema::Schema>::SCHEMA,
+            ),
+            name: #method_name_str,
+            input_schema: <#input_type_name as ::plugcard::postcard_schema::Schema>::SCHEMA,
+            output_schema: <#return_type as ::plugcard::postcard_schema::Schema>::SCHEMA,
+            call: #wrapper_name,
+        };
+    };
+
+    Ok(output)
+}

--- a/crates/plugcard/Cargo.toml
+++ b/crates/plugcard/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "plugcard"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.85"
+description = "Dynamic library plugin system with serialized method calls"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[dependencies]
+# Serialization
+postcard = { version = "1", features = ["alloc"] }
+serde = { version = "1", features = ["derive"] }
+
+# Schema introspection
+postcard-schema = { version = "0.1", features = ["derive", "alloc"] }
+
+# Distributed slices for method registration
+linkme = "0.3"
+
+# Re-export the proc macro
+plugcard-macros = { path = "../plugcard-macros" }

--- a/crates/plugcard/src/lib.rs
+++ b/crates/plugcard/src/lib.rs
@@ -1,0 +1,136 @@
+//! Plugcard: Dynamic library plugin system with serialized method calls
+//!
+//! Inspired by postcard-rpc, this provides a way to load plugins as dynamic
+//! libraries and call methods using serialized data across the FFI boundary.
+
+use linkme::distributed_slice;
+
+/// Distributed slice containing all registered method signatures
+#[distributed_slice]
+pub static METHODS: [MethodSignature];
+
+/// A method signature with schema information for introspection
+#[derive(Debug, Clone)]
+pub struct MethodSignature {
+    /// Unique key derived from method name and type schemas
+    pub key: u64,
+    /// Human-readable method name
+    pub name: &'static str,
+    /// Schema for the input type
+    pub input_schema: &'static postcard_schema::schema::NamedType,
+    /// Schema for the output type
+    pub output_schema: &'static postcard_schema::schema::NamedType,
+    /// The wrapper function to call
+    pub call: unsafe extern "C" fn(*mut MethodCallData),
+}
+
+/// Data passed to method wrappers across FFI boundary
+#[repr(C)]
+pub struct MethodCallData {
+    /// Method signature key (for validation)
+    pub key: u64,
+    /// Pointer to serialized input data
+    pub input_ptr: *const u8,
+    /// Length of input data
+    pub input_len: usize,
+    /// Pointer to output buffer (caller-allocated)
+    pub output_ptr: *mut u8,
+    /// Capacity of output buffer
+    pub output_cap: usize,
+    /// Actual length written to output (set by callee)
+    pub output_len: usize,
+    /// Result status
+    pub result: MethodCallResult,
+}
+
+/// Result of a method call
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MethodCallResult {
+    /// Call succeeded, output contains serialized result
+    #[default]
+    Success,
+    /// Failed to deserialize input
+    DeserializeError,
+    /// Failed to serialize output (buffer too small?)
+    SerializeError,
+    /// Method returned an error (serialized in output)
+    MethodError,
+    /// Unknown method key
+    UnknownMethod,
+}
+
+/// Find a method by its key
+pub fn find_method(key: u64) -> Option<&'static MethodSignature> {
+    METHODS.iter().find(|m| m.key == key)
+}
+
+/// Dispatch a method call by key
+///
+/// # Safety
+/// - `data` must point to valid MethodCallData
+/// - input_ptr/input_len must be valid
+/// - output_ptr/output_cap must be valid writable buffer
+pub unsafe fn dispatch(data: *mut MethodCallData) {
+    unsafe {
+        let data_ref = &mut *data;
+
+        if let Some(method) = find_method(data_ref.key) {
+            (method.call)(data);
+        } else {
+            data_ref.result = MethodCallResult::UnknownMethod;
+        }
+    }
+}
+
+/// Compute a method key from name and schemas (const-compatible FNV-1a hash)
+pub const fn compute_key(name: &str, input_schema: &postcard_schema::schema::NamedType, output_schema: &postcard_schema::schema::NamedType) -> u64 {
+    // FNV-1a hash constants
+    const FNV_OFFSET: u64 = 0xcbf29ce484222325;
+    const FNV_PRIME: u64 = 0x100000001b3;
+
+    let mut hash = FNV_OFFSET;
+
+    // Hash name
+    let name_bytes = name.as_bytes();
+    let mut i = 0;
+    while i < name_bytes.len() {
+        hash ^= name_bytes[i] as u64;
+        hash = hash.wrapping_mul(FNV_PRIME);
+        i += 1;
+    }
+
+    // Hash input schema name
+    let input_bytes = input_schema.name.as_bytes();
+    let mut i = 0;
+    while i < input_bytes.len() {
+        hash ^= input_bytes[i] as u64;
+        hash = hash.wrapping_mul(FNV_PRIME);
+        i += 1;
+    }
+
+    // Hash output schema name
+    let output_bytes = output_schema.name.as_bytes();
+    let mut i = 0;
+    while i < output_bytes.len() {
+        hash ^= output_bytes[i] as u64;
+        hash = hash.wrapping_mul(FNV_PRIME);
+        i += 1;
+    }
+
+    hash
+}
+
+/// List all available methods (for introspection)
+pub fn list_methods() -> &'static [MethodSignature] {
+    &METHODS
+}
+
+// Re-exports for macro use
+pub use linkme;
+pub use postcard;
+pub use postcard_schema;
+pub use serde;
+
+// Re-export the proc macro
+pub use plugcard_macros::plugcard;

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -3,76 +3,11 @@ title = "dodeca"
 description = "A fully incremental static site generator"
 +++
 
-A fully incremental static site generator built with Rust. Now with LIVE PATCHING!
+A fully incremental static site generator built with Rust.
 
-## Contents
+**Zero reloads.** When you edit content, dodeca patches the DOM surgically via WASM. No flash of white. No scroll position lost.
 
-- [Features](#features)
-- [Installation](#installation)
-- [Quick Start](#quick-start)
-- [Configuration](#configuration)
-- [License](#license)
-
-## Features
-
-- **Incremental builds** via [Salsa](https://salsa-rs.github.io/salsa/) - only rebuild what changed
-- **DOM patching** - no full reload, just surgical DOM updates via WASM
-- **Font subsetting** - only include glyphs actually used on your site (saves TONS of bandwidth!)
-- **OG image generation** with Typst - gorgeous social cards, zero effort
-- **Live-reload dev server** - instant feedback while editing
-- **Jinja-like template engine** - familiar syntax, zero serde
-- **Sass/SCSS compilation** - modern CSS workflow built-in
-- **Search indexing** via Pagefind - fast client-side search
-- **Link checking** - catch broken internal and external links
-
-## Installation
-
-### macOS / Linux
-
-```bash
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/bearcove/dodeca/releases/latest/download/dodeca-installer.sh | sh
-```
-
-### Windows
-
-```powershell
-powershell -ExecutionPolicy Bypass -c "irm https://github.com/bearcove/dodeca/releases/latest/download/dodeca-installer.ps1 | iex"
-```
-
-### Homebrew
-
-```bash
-brew install bearcove/tap/dodeca
-```
-
-### From source
-
-```bash
-cargo install dodeca
-```
-
-## Quick Start
-
-```bash
-# Build your site
-ddc build
-
-# Serve with live reload
-ddc serve
-```
-
-## Configuration
-
-Create `.config/dodeca.kdl` in your project root:
-
-```kdl
-content "docs/content"
-output "docs/public"
-```
-
-## License
-
-Licensed under either of Apache License, Version 2.0 or MIT license at your option.
+**Truly incremental.** Powered by [Salsa](https://salsa-rs.github.io/salsa/), dodeca only rebuilds what actually changed.
 
 ![Mountain landscape](/images/mountain.jpg)
 

--- a/docs/content/guide/_index.md
+++ b/docs/content/guide/_index.md
@@ -1,0 +1,6 @@
++++
+title = "Guide"
+weight = 10
++++
+
+Getting started with dodeca.

--- a/docs/content/guide/configuration.md
+++ b/docs/content/guide/configuration.md
@@ -1,0 +1,48 @@
++++
+title = "Configuration"
+description = "Configuring dodeca"
+weight = 30
++++
+
+Configuration lives in `.config/dodeca.kdl` in your project root.
+
+## Basic settings
+
+```kdl
+content "docs/content"
+output "docs/public"
+```
+
+## Link checking
+
+Enable broken link detection:
+
+```kdl
+link_check {
+}
+```
+
+## Stable assets
+
+Some assets (like favicons) should keep stable URLs for caching:
+
+```kdl
+stable_assets {
+    path "favicon.svg"
+    path "robots.txt"
+}
+```
+
+## Full example
+
+```kdl
+content "docs/content"
+output "docs/public"
+
+link_check {
+}
+
+stable_assets {
+    path "favicon.svg"
+}
+```

--- a/docs/content/guide/features.md
+++ b/docs/content/guide/features.md
@@ -1,0 +1,27 @@
++++
+title = "Features"
+description = "What dodeca offers"
+weight = 40
++++
+
+## Build
+
+- **Incremental builds** via [Salsa](https://salsa-rs.github.io/salsa/) - only rebuild what changed
+- **Sass/SCSS compilation** - modern CSS workflow built-in
+- **Search indexing** via Pagefind - fast client-side search
+- **Link checking** - catch broken internal and external links
+
+## Runtime
+
+- **DOM patching** - no full reload, just surgical DOM updates via WASM
+- **Live-reload dev server** - instant feedback while editing
+
+## Assets
+
+- **Font subsetting** - only include glyphs actually used on your site (saves TONS of bandwidth!)
+- **OG image generation** with Typst - gorgeous social cards, zero effort
+- **Responsive images** - automatic JXL/WebP variants at multiple sizes
+
+## Templating
+
+- **Jinja-like template engine** - familiar syntax, zero serde

--- a/docs/content/guide/installation.md
+++ b/docs/content/guide/installation.md
@@ -1,0 +1,37 @@
++++
+title = "Installation"
+description = "How to install dodeca"
+weight = 10
++++
+
+## macOS / Linux
+
+```bash
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/bearcove/dodeca/releases/latest/download/dodeca-installer.sh | sh
+```
+
+## Windows
+
+```powershell
+powershell -ExecutionPolicy Bypass -c "irm https://github.com/bearcove/dodeca/releases/latest/download/dodeca-installer.ps1 | iex"
+```
+
+## Homebrew
+
+```bash
+brew install bearcove/tap/dodeca
+```
+
+## From source
+
+```bash
+cargo install dodeca
+```
+
+## Verify
+
+After installation, verify it works:
+
+```bash
+ddc --version
+```

--- a/docs/content/guide/quick-start.md
+++ b/docs/content/guide/quick-start.md
@@ -1,0 +1,67 @@
++++
+title = "Quick Start"
+description = "Get up and running with dodeca"
+weight = 20
++++
+
+## Create a project
+
+Create a new directory for your site:
+
+```bash
+mkdir my-site
+cd my-site
+```
+
+## Add configuration
+
+Create `.config/dodeca.kdl`:
+
+```kdl
+content "content"
+output "public"
+```
+
+## Create content
+
+Create `content/_index.md`:
+
+```markdown
++++
+title = "My Site"
++++
+
+Hello, world!
+```
+
+## Create a template
+
+Create `templates/index.html`:
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{{ section.title }}</title>
+</head>
+<body>
+    {{ section.content | safe }}
+</body>
+</html>
+```
+
+## Build
+
+```bash
+ddc build
+```
+
+Your site is now in `public/`.
+
+## Serve with live reload
+
+```bash
+ddc serve
+```
+
+Open http://localhost:4000 and start editing. Changes appear instantly.

--- a/docs/content/ideas/_index.md
+++ b/docs/content/ideas/_index.md
@@ -1,0 +1,6 @@
++++
+title = "Ideas"
+weight = 30
++++
+
+Features and concepts not yet implemented.

--- a/docs/content/ideas/randomness.md
+++ b/docs/content/ideas/randomness.md
@@ -1,0 +1,46 @@
++++
+title = "Randomness"
+description = "Handling random values in incremental builds"
+weight = 10
++++
+
+**Status: Design idea, not yet implemented**
+
+## Problem
+
+Some site features need "randomness":
+- "Random article" links
+- Shuffled content blocks
+- A/B test variants
+
+But randomness breaks incremental builds - if outputs change every build, nothing is cached.
+
+## Solution
+
+**Dev mode**: Random values come from fixed input (a constant seed). They never change, so:
+- Incremental builds work perfectly
+- Live reload doesn't thrash
+- Developers see consistent output
+
+**Production builds**: Generate a fresh seed at build time. Random values actually vary:
+- Each deployment gets different "random" picks
+- Still deterministic within a single build (same seed = same output)
+
+## Implementation Ideas
+
+```rust
+// In template context
+fn random_seed(&self) -> u64 {
+    if self.is_dev_mode {
+        0xDEADBEEF  // Fixed seed for dev
+    } else {
+        self.build_seed  // Generated at build start
+    }
+}
+
+// Template usage
+{% set rng = random_seed() %}
+{% set random_article = articles | shuffle(seed=rng) | first %}
+```
+
+This keeps the randomness as *input* to the build, making it cacheable.

--- a/docs/content/internals/_index.md
+++ b/docs/content/internals/_index.md
@@ -1,0 +1,6 @@
++++
+title = "Internals"
+weight = 20
++++
+
+How dodeca works under the hood.

--- a/docs/content/internals/cache-busting.md
+++ b/docs/content/internals/cache-busting.md
@@ -1,0 +1,28 @@
++++
+title = "Cache Busting"
+weight = 21
++++
+
+Every asset except HTML pages gets a content hash in its filename: `style.css` becomes `style.kj7m2x.css`. All references are rewritten to match, so you can serve assets with `Cache-Control: immutable` and never worry about stale caches.
+
+```html
+<link href="/css/style.kj7m2x.css">
+<img src="/images/logo.m4n8p2.png">
+```
+
+CSS `url()` values are rewritten too:
+
+```css
+@font-face { src: url('/fonts/inter.x9k3j1.woff2'); }
+```
+
+Some files need stable paths (favicons, robots.txt). Configure them in `dodeca.kdl`:
+
+```kdl
+stable_assets {
+    path "favicon.svg"
+    path "robots.txt"
+}
+```
+
+When a file changes, only that file is re-hashed, and only pages referencing it are regenerated.

--- a/docs/content/internals/dual-cache.md
+++ b/docs/content/internals/dual-cache.md
@@ -1,0 +1,14 @@
++++
+title = "Dual Cache Architecture"
+weight = 31
++++
+
+dodeca uses two caches: Salsa for the computation graph, and a content-addressed store for large blobs.
+
+Salsa tracks dependencies and stores small outputs like parsed frontmatter, rendered HTML, and template ASTs. It stays in memory during a session and persists between runs.
+
+Large outputs—processed images, subsetted fonts, any binary blob—go to a separate content-addressed store backed by [CanopyDB](https://github.com/bearcove/canopydb). Files are named by content hash, so identical content is never stored twice.
+
+When you edit a markdown file, Salsa invalidates just the affected queries. The rendered HTML recomputes, but images with unchanged content skip reprocessing entirely—their hash is already in the CAS.
+
+On startup, both caches load from disk. Most queries return cached results instantly; only truly changed content recomputes. Even a "cold" build is warm if you've built before.

--- a/docs/content/internals/font-subsetting.md
+++ b/docs/content/internals/font-subsetting.md
@@ -1,0 +1,17 @@
++++
+title = "Font Subsetting"
+weight = 32
++++
+
+dodeca scans all rendered HTML to find which characters are actually used, then strips everything else from your font files. A 300KB font typically becomes 15-30KB.
+
+After rendering, we collect every character that appears in the output. For each font file, [fontcull](https://github.com/bearcove/fontcull) removes unused glyphs and OpenType features. The subsetted font gets a content hash and CSS `@font-face` rules are rewritten to match.
+
+Most edits don't introduce new characters, so the subsetted font stays cached. When the character set does change, only fonts containing those characters are re-subset.
+
+Variable fonts work too—subsetting preserves variation axes while removing unused glyphs.
+
+```
+fonts/inter.woff2: 285KB → 24KB (91% reduction)
+fonts/fira-code.woff2: 178KB → 18KB (90% reduction)
+```

--- a/docs/content/internals/images.md
+++ b/docs/content/internals/images.md
@@ -1,0 +1,26 @@
++++
+title = "Image Processing"
+weight = 23
++++
+
+A single markdown image becomes a responsive `<picture>` with JPEG XL, WebP, and JPEG fallbacks at multiple sizes:
+
+```html
+<picture>
+  <source srcset="/images/mountain.400w.jxl 400w,
+                  /images/mountain.800w.jxl 800w,
+                  /images/mountain.1200w.jxl 1200w"
+          type="image/jxl">
+  <source srcset="..." type="image/webp">
+  <img src="/images/mountain.800w.jpg"
+       srcset="..."
+       alt="Mountain landscape"
+       loading="lazy">
+</picture>
+```
+
+Browsers pick the best format they support. All images get `loading="lazy"`.
+
+Processed images are cached in `.cache/images.canopy`. Unchanged images skip reprocessing entirely.
+
+dodeca also generates Open Graph images for social sharing using [resvg](https://github.com/RazrFalcon/resvg), rendered from SVG templates.

--- a/docs/content/internals/live-reload.md
+++ b/docs/content/internals/live-reload.md
@@ -1,0 +1,23 @@
++++
+title = "Live Reload"
+weight = 22
++++
+
+Instead of refreshing the page, dodeca patches the DOM directly. You keep your scroll position, form state, and focus.
+
+When a file changes, Salsa rebuilds only what's affected. The server diffs the old and new HTML, computes minimal edit operations, and sends them over WebSocket. A small WASM client applies the patches—replacing nodes, updating text, adding or removing attributes—without touching anything that didn't change.
+
+```rust
+enum Patch {
+    Replace { path: NodePath, html: String },
+    InsertBefore { path: NodePath, html: String },
+    Remove { path: NodePath },
+    SetText { path: NodePath, text: String },
+    SetAttribute { path: NodePath, name: String, value: String },
+    // ...
+}
+```
+
+CSS is simpler: we just update the `<link>` href to the new cache-busted URL and let the browser fetch it.
+
+If patching fails (rare), we fall back to a full reload.

--- a/docs/content/internals/minification.md
+++ b/docs/content/internals/minification.md
@@ -1,0 +1,18 @@
++++
+title = "Minification"
+weight = 33
++++
+
+Production builds (`ddc build`) minify everything. Dev server keeps output readable unless you pass `--release`.
+
+**HTML** via [minify-html](https://github.com/nickmass/minify-html): collapses whitespace, omits optional tags, strips comments, removes unnecessary quotes.
+
+```html
+<div class=container><p>Hello, world!
+```
+
+**CSS** via [lightningcss](https://lightningcss.dev/): merges rules, shortens colors, eliminates dead code, handles vendor prefixes.
+
+**JavaScript** via [OXC](https://oxc.rs/): renames variables, folds constants, eliminates dead code, tree shakes.
+
+**SVG** via [svgcleaner](https://github.com/nickmass/svag): removes metadata, collapses groups, optimizes paths.

--- a/docs/content/internals/plugins.md
+++ b/docs/content/internals/plugins.md
@@ -1,0 +1,205 @@
++++
+title = "Plugins"
+description = "Dynamic library plugin system with serialized method calls"
+weight = 50
++++
+
+A dynamic library plugin system for Rust, inspired by [postcard-rpc](https://github.com/jamesmunns/postcard-rpc).
+
+## Overview
+
+Plugcard allows you to expose Rust functions as plugin methods that can be called across dynamic library boundaries. It handles:
+
+- **Serialization** - Input/output automatically serialized via [postcard](https://docs.rs/postcard)
+- **Schema introspection** - Methods carry type schemas for validation
+- **Auto-registration** - Methods register themselves via [linkme](https://docs.rs/linkme) distributed slices
+- **FFI safety** - Clean C-compatible interface across the boundary
+
+## Quick Start
+
+### 1. Add dependencies
+
+```toml
+[dependencies]
+plugcard = { path = "../plugcard" }
+linkme = "0.3"
+postcard-schema = { version = "0.1", features = ["derive", "alloc"] }
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+```
+
+### 2. Mark functions with `#[plugcard]`
+
+```rust
+use plugcard::plugcard;
+
+#[plugcard]
+pub fn reverse_string(input: String) -> String {
+    input.chars().rev().collect()
+}
+
+#[plugcard]
+pub fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+```
+
+That's it! The macro generates all the FFI wrappers and registration code.
+
+## How It Works
+
+The `#[plugcard]` attribute macro transforms your function into a plugin method:
+
+1. **Input struct** - Arguments are bundled into a generated struct with serde derives
+2. **FFI wrapper** - An `extern "C"` function that deserializes input, calls your function, serializes output
+3. **Registration** - A static `MethodSignature` is registered in a distributed slice
+
+### Generated Code
+
+For a function like:
+
+```rust
+#[plugcard]
+pub fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+```
+
+The macro generates:
+
+```rust
+// Original function preserved
+pub fn add(a: i32, b: i32) -> i32 { a + b }
+
+// Input composite type
+#[derive(Serialize, Deserialize, Schema)]
+struct __PlugcardInput_add { pub a: i32, pub b: i32 }
+
+// C-compatible wrapper
+unsafe extern "C" fn __plugcard_wrapper_add(data: *mut MethodCallData) {
+    // Deserialize input
+    let input: __PlugcardInput_add = postcard::from_bytes(...)?;
+    // Call function
+    let result = add(input.a, input.b);
+    // Serialize output
+    postcard::to_slice(&result, ...)?;
+}
+
+// Auto-register in distributed slice
+#[distributed_slice(METHODS)]
+static __PLUGCARD_SIG_add: MethodSignature = MethodSignature {
+    key: compute_key("add", ...),
+    name: "add",
+    input_schema: ...,
+    output_schema: ...,
+    call: __plugcard_wrapper_add,
+};
+```
+
+## API Reference
+
+### `MethodSignature`
+
+```rust
+pub struct MethodSignature {
+    pub key: u64,           // Unique key from name + schemas
+    pub name: &'static str, // Human-readable method name
+    pub input_schema: &'static NamedType,
+    pub output_schema: &'static NamedType,
+    pub call: unsafe extern "C" fn(*mut MethodCallData),
+}
+```
+
+### `MethodCallData`
+
+The FFI boundary structure:
+
+```rust
+#[repr(C)]
+pub struct MethodCallData {
+    pub key: u64,
+    pub input_ptr: *const u8,
+    pub input_len: usize,
+    pub output_ptr: *mut u8,
+    pub output_cap: usize,
+    pub output_len: usize,  // Set by callee
+    pub result: MethodCallResult,
+}
+```
+
+### `MethodCallResult`
+
+```rust
+#[repr(C)]
+pub enum MethodCallResult {
+    Success,
+    DeserializeError,
+    SerializeError,
+    MethodError,
+    UnknownMethod,
+}
+```
+
+### Introspection Functions
+
+```rust
+// Find a method by its computed key
+pub fn find_method(key: u64) -> Option<&'static MethodSignature>
+
+// List all registered methods
+pub fn list_methods() -> &'static [MethodSignature]
+
+// Dispatch a call by key
+pub unsafe fn dispatch(data: *mut MethodCallData)
+```
+
+## Calling a Plugin Method
+
+```rust
+use plugcard::{list_methods, MethodCallData, MethodCallResult};
+
+// Find the method
+let methods = list_methods();
+let add = methods.iter().find(|m| m.name == "add").unwrap();
+
+// Prepare input (must match the generated input struct layout)
+#[derive(Serialize)]
+struct Input { a: i32, b: i32 }
+let input_bytes = postcard::to_allocvec(&Input { a: 2, b: 3 }).unwrap();
+
+// Prepare output buffer
+let mut output_buf = [0u8; 256];
+let mut data = MethodCallData {
+    key: add.key,
+    input_ptr: input_bytes.as_ptr(),
+    input_len: input_bytes.len(),
+    output_ptr: output_buf.as_mut_ptr(),
+    output_cap: output_buf.len(),
+    output_len: 0,
+    result: MethodCallResult::default(),
+};
+
+// Call
+unsafe { (add.call)(&mut data) };
+
+// Check result
+assert_eq!(data.result, MethodCallResult::Success);
+let result: i32 = postcard::from_bytes(&output_buf[..data.output_len]).unwrap();
+assert_eq!(result, 5);
+```
+
+## Method Keys
+
+Method keys are computed at compile time using FNV-1a hash of:
+- Method name
+- Input schema name
+- Output schema name
+
+This ensures type-safe dispatch: if schemas change, keys change.
+
+## Crate Structure
+
+- **plugcard** - Core types and runtime
+- **plugcard-macros** - The `#[plugcard]` proc macro (uses [unsynn](https://docs.rs/unsynn) for parsing)
+- **dodeca-baseline** - Example plugin with test functions

--- a/docs/content/internals/queries.md
+++ b/docs/content/internals/queries.md
@@ -1,0 +1,22 @@
++++
+title = "Query Reference"
+weight = 30
++++
+
+Every computation is a Salsa query. Queries are memoized and track dependencies automatically.
+
+**Inputs** (raw data from disk): `SourceFile`, `TemplateFile`, `SassFile`, `StaticFile`, `OgTemplateFile`.
+
+**Content**: `parse_file` → `build_tree` → `render_page` / `render_section` → `all_rendered_html` → `build_site`.
+
+**Templates**: `load_template` → `load_all_templates` → renders.
+
+**Styles**: `load_sass` → `compile_sass` → `css_output` (cache-busted).
+
+**Images**: `image_metadata` → `image_input_hash` → `process_image` (JXL + WebP at multiple sizes).
+
+**Fonts**: `font_char_analysis` (find used chars) → `subset_font`.
+
+**Assets**: `optimize_svg`, `static_file_output` (cache-busted).
+
+**OG images**: `render_og_image` (PNG via Typst).

--- a/docs/content/internals/salsa.md
+++ b/docs/content/internals/salsa.md
@@ -1,0 +1,17 @@
++++
+title = "Salsa"
+description = "How dodeca tracks dependencies and only rebuilds what changed"
+weight = 1
++++
+
+dodeca is built on [Salsa](https://salsa-rs.github.io/salsa/). Everything is a query; queries are memoized functions that track which inputs they read.
+
+When you change a file, Salsa traces exactly which outputs depend on it and only recomputes those. Edit `features.md` and only that page re-renders—other pages, CSS, images, and fonts stay cached.
+
+```
+SourceFile → parse_file → build_tree → render_page → all_rendered_html → build_site
+                                ↑
+TemplateFile → load_template ───┘
+```
+
+The cache persists to disk. Even a cold start benefits from previous work. Large outputs (images, fonts) are stored separately in content-addressed storage to keep the Salsa database small.

--- a/docs/content/internals/templates.md
+++ b/docs/content/internals/templates.md
@@ -1,0 +1,25 @@
++++
+title = "Template Engine"
+weight = 20
++++
+
+dodeca includes a Jinja-like template engine built for tight integration with Salsa's incremental computation.
+
+```jinja
+{% extends "base.html" %}
+
+{% block content %}
+  <h1>{{ page.title }}</h1>
+  {{ page.content | safe }}
+
+  {% for p in section.pages %}
+    <a href="{{ p.permalink }}">{{ p.title }}</a>
+  {% endfor %}
+{% endblock %}
+```
+
+Templates receive `page` (title, content, permalink, toc), `section` (title, content, pages, subsections), and `config`.
+
+Filters: `safe` (no escaping), `upper`, `lower`, `trim`, `default(value)`.
+
+All output is HTML-escaped by default. Use `| safe` for pre-rendered HTML like `page.content`.

--- a/docs/static/css/style.css
+++ b/docs/static/css/style.css
@@ -33,13 +33,17 @@
 
 :root {
     --bg: #0a0a0a;
-    --fg: #e5e5e5;
-    --muted: #737373;
-    --accent: #6a8a6a;
-    --code-bg: #1a1a1a;
+    --bg-raised: #111;
+    --fg: #d4d4d4;
+    --fg-muted: #737373;
+    --accent: #7aba7a;
+    --accent-dim: #5d8a5d;
+    --code-bg: #161616;
     --border: #262626;
     --font-sans: 'Public Sans', -apple-system, BlinkMacSystemFont, sans-serif;
     --font-mono: 'Iosevka', 'SF Mono', Consolas, monospace;
+    --sidebar-width: 220px;
+    --content-max: 720px;
 }
 
 * {
@@ -62,23 +66,26 @@ body {
     flex-direction: column;
 }
 
-/* Navigation */
+/* ============================================
+   Navigation
+   ============================================ */
 .site-nav {
     display: flex;
     align-items: center;
     gap: 1.5rem;
-    padding: 1rem 2rem;
+    padding: 0.75rem 1.5rem;
     border-bottom: 1px solid var(--border);
-    max-width: 1200px;
-    margin: 0 auto;
-    width: 100%;
+    background: var(--bg);
+    position: sticky;
+    top: 0;
+    z-index: 100;
 }
 
 .site-nav-brand {
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    font-size: 1.5rem;
+    font-size: 1.25rem;
     font-weight: 700;
     color: var(--fg);
     text-decoration: none;
@@ -88,33 +95,17 @@ body {
     flex-shrink: 0;
 }
 
-.site-nav-links {
-    display: flex;
-    gap: 1.5rem;
-}
-
-.site-nav-links a {
-    color: var(--muted);
-    text-decoration: none;
-    font-weight: 500;
-    transition: color 0.2s;
-}
-
-.site-nav-links a:hover {
-    color: var(--fg);
-}
-
 .site-nav-spacer {
     flex: 1;
 }
 
 .site-nav-search {
-    width: 300px;
+    width: 240px;
     position: relative;
 }
 
 .site-nav-github {
-    color: var(--muted);
+    color: var(--fg-muted);
     transition: color 0.2s;
 }
 
@@ -122,110 +113,183 @@ body {
     color: var(--fg);
 }
 
-/* Pagefind customization */
-.pagefind-ui {
-    --pagefind-ui-scale: 0.8;
-    --pagefind-ui-primary: var(--accent);
-    --pagefind-ui-text: var(--fg);
-    --pagefind-ui-background: var(--code-bg);
-    --pagefind-ui-border: var(--border);
-    --pagefind-ui-tag: var(--code-bg);
-    --pagefind-ui-border-width: 1px;
-    --pagefind-ui-border-radius: 6px;
-    --pagefind-ui-font: inherit;
+/* ============================================
+   Hero Section (homepage only)
+   ============================================ */
+.hero {
+    padding: 4rem 2rem;
+    text-align: center;
+    border-bottom: 1px solid var(--border);
+    background: linear-gradient(180deg, var(--bg) 0%, var(--bg-raised) 100%);
 }
 
-.pagefind-ui__search-input {
-    background: var(--code-bg) !important;
-    color: var(--fg) !important;
-}
-
-.pagefind-ui__search-input::placeholder {
-    color: var(--muted) !important;
-}
-
-/* Results container - position as dropdown overlay */
-.pagefind-ui__drawer {
-    position: absolute !important;
-    right: 0 !important;
-    left: auto !important;
-    top: 100% !important;
-    width: 420px !important;
-    max-width: calc(100vw - 2rem) !important;
-    max-height: 80vh !important;
-    overflow-y: auto !important;
-    background: var(--code-bg) !important;
-    border: 1px solid var(--border) !important;
-    border-radius: 8px !important;
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4) !important;
-    margin-top: 0.5rem !important;
-    z-index: 1000 !important;
-    padding: 0 1rem !important;
-}
-
-.pagefind-ui__message {
-    font-size: 0.8rem !important;
-    padding: 0.5rem !important;
-    color: var(--muted) !important;
-}
-
-.pagefind-ui__result {
-    padding: 0.75rem 0 !important;
-    border-bottom: 1px solid var(--border) !important;
-}
-
-.pagefind-ui__result:last-child {
-    border-bottom: none !important;
-}
-
-.pagefind-ui__result-link {
-    color: var(--accent) !important;
-    text-decoration: none !important;
-}
-
-.pagefind-ui__result-link:hover {
-    text-decoration: underline !important;
-}
-
-.pagefind-ui__result-excerpt {
-    font-size: 0.85rem !important;
-    line-height: 1.4 !important;
-    color: var(--muted) !important;
-    margin-top: 0.25rem !important;
-}
-
-.pagefind-ui__result-excerpt mark {
-    background: var(--accent) !important;
-    color: #fff !important;
-    padding: 0.1em 0.25em !important;
-    border-radius: 2px !important;
-}
-
-/* Main content */
-.container {
-    flex: 1;
-    max-width: 800px;
+.hero-content {
+    max-width: 600px;
     margin: 0 auto;
-    padding: 3rem 2rem;
+}
+
+.hero-title {
+    font-size: 3.5rem;
+    font-weight: 700;
+    color: var(--fg);
+    margin-bottom: 0.5rem;
+    letter-spacing: -0.02em;
+}
+
+.hero-tagline {
+    font-size: 1.5rem;
+    color: var(--accent);
+    margin-bottom: 0.5rem;
+    font-weight: 500;
+}
+
+.hero-sub {
+    font-size: 1rem;
+    color: var(--fg-muted);
+    margin-bottom: 2rem;
+}
+
+.hero-actions {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+
+.btn {
+    display: inline-block;
+    padding: 0.75rem 1.5rem;
+    border-radius: 6px;
+    font-weight: 600;
+    text-decoration: none;
+    transition: all 0.2s;
+}
+
+.btn-primary {
+    background: var(--accent);
+    color: #000;
+}
+
+.btn-primary:hover {
+    background: var(--accent-dim);
+}
+
+.btn-secondary {
+    background: transparent;
+    color: var(--fg);
+    border: 1px solid var(--border);
+}
+
+.btn-secondary:hover {
+    border-color: var(--fg-muted);
+}
+
+/* ============================================
+   Layout (sidebar + content)
+   ============================================ */
+.layout {
+    display: flex;
+    flex: 1;
+    max-width: 1100px;
+    margin: 0 auto;
     width: 100%;
 }
 
+/* ============================================
+   Sidebar
+   ============================================ */
+.sidebar {
+    width: var(--sidebar-width);
+    flex-shrink: 0;
+    padding: 2rem 1.5rem;
+    border-right: 1px solid var(--border);
+    position: sticky;
+    top: 53px; /* nav height */
+    height: calc(100vh - 53px);
+    overflow-y: auto;
+}
+
+.sidebar-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.sidebar-section h3 {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 0.75rem;
+}
+
+.sidebar-section h3 a {
+    color: var(--fg-muted);
+    text-decoration: none;
+    transition: color 0.15s;
+}
+
+.sidebar-section h3 a:hover {
+    color: var(--fg);
+}
+
+.sidebar-section ul {
+    list-style: none;
+}
+
+.sidebar-section li {
+    margin-bottom: 0.25rem;
+}
+
+.sidebar-section a {
+    display: block;
+    padding: 0.375rem 0.75rem;
+    color: var(--fg-muted);
+    text-decoration: none;
+    font-size: 0.9rem;
+    border-radius: 4px;
+    transition: all 0.15s;
+}
+
+.sidebar-section a:hover {
+    color: var(--fg);
+    background: var(--bg-raised);
+}
+
+.sidebar-section a.active {
+    color: var(--accent);
+    background: rgba(122, 186, 122, 0.1);
+}
+
+/* ============================================
+   Main Content
+   ============================================ */
+.content {
+    flex: 1;
+    min-width: 0;
+    padding: 2rem 3rem;
+    max-width: var(--content-max);
+}
+
 article h1 {
-    font-size: 2.5rem;
+    font-size: 2rem;
     margin-bottom: 1.5rem;
     font-weight: 700;
+    color: var(--fg);
 }
 
 article h2 {
-    font-size: 1.5rem;
+    font-size: 1.35rem;
     margin-top: 2.5rem;
     margin-bottom: 1rem;
     font-weight: 600;
     color: var(--fg);
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--border);
 }
 
 article h3 {
-    font-size: 1.2rem;
+    font-size: 1.1rem;
     margin-top: 2rem;
     margin-bottom: 0.75rem;
     font-weight: 600;
@@ -233,7 +297,6 @@ article h3 {
 
 article p {
     margin-bottom: 1rem;
-    color: var(--fg);
 }
 
 article ul, article ol {
@@ -257,11 +320,13 @@ article a:hover {
 article img {
     max-width: 100%;
     height: auto;
+    border-radius: 8px;
+    margin: 1rem 0;
 }
 
 article code {
     font-family: var(--font-mono);
-    font-size: 0.9em;
+    font-size: 0.875em;
     background: var(--code-bg);
     padding: 0.2em 0.4em;
     border-radius: 4px;
@@ -269,8 +334,8 @@ article code {
 
 article pre {
     background: var(--code-bg);
-    padding: 1rem;
-    border-radius: 8px;
+    padding: 0.75rem 1rem;
+    border-radius: 6px;
     overflow-x: auto;
     margin-bottom: 1rem;
     border: 1px solid var(--border);
@@ -279,42 +344,181 @@ article pre {
 article pre code {
     background: none;
     padding: 0;
-    font-size: 0.875rem;
+    font-size: 0.85rem;
     line-height: 1.5;
 }
 
 article strong {
     font-weight: 600;
+    color: var(--fg);
 }
 
+article em {
+    color: var(--fg-muted);
+}
+
+article table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 1.5rem 0;
+    font-size: 0.9rem;
+}
+
+article th, article td {
+    padding: 0.75rem 1rem;
+    text-align: left;
+    border-bottom: 1px solid var(--border);
+}
+
+article th {
+    font-weight: 600;
+    color: var(--fg);
+    background: var(--bg-raised);
+}
+
+article tr:hover td {
+    background: rgba(255, 255, 255, 0.02);
+}
+
+/* ============================================
+   Footer
+   ============================================ */
 footer {
     border-top: 1px solid var(--border);
-    padding: 2rem;
+    padding: 1.5rem;
     text-align: center;
-    color: var(--muted);
-    font-size: 0.875rem;
+    color: var(--fg-muted);
+    font-size: 0.8rem;
 }
 
-@media (max-width: 640px) {
+footer a {
+    color: var(--accent-dim);
+    text-decoration: none;
+    transition: color 0.15s;
+}
+
+footer a:hover {
+    color: var(--accent);
+}
+
+/* ============================================
+   Pagefind Search
+   ============================================ */
+.pagefind-ui {
+    --pagefind-ui-scale: 0.75;
+    --pagefind-ui-primary: var(--accent);
+    --pagefind-ui-text: var(--fg);
+    --pagefind-ui-background: var(--code-bg);
+    --pagefind-ui-border: var(--border);
+    --pagefind-ui-tag: var(--code-bg);
+    --pagefind-ui-border-width: 1px;
+    --pagefind-ui-border-radius: 6px;
+    --pagefind-ui-font: inherit;
+}
+
+.pagefind-ui__search-input {
+    background: var(--code-bg) !important;
+    color: var(--fg) !important;
+}
+
+.pagefind-ui__search-input::placeholder {
+    color: var(--fg-muted) !important;
+}
+
+.pagefind-ui__drawer {
+    position: absolute !important;
+    right: 0 !important;
+    left: auto !important;
+    top: 100% !important;
+    width: 380px !important;
+    max-width: calc(100vw - 2rem) !important;
+    max-height: 70vh !important;
+    overflow-y: auto !important;
+    background: var(--bg-raised) !important;
+    border: 1px solid var(--border) !important;
+    border-radius: 8px !important;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5) !important;
+    margin-top: 0.5rem !important;
+    z-index: 1000 !important;
+    padding: 0 1rem !important;
+}
+
+.pagefind-ui__message {
+    font-size: 0.8rem !important;
+    padding: 0.5rem !important;
+    color: var(--fg-muted) !important;
+}
+
+.pagefind-ui__result {
+    padding: 0.75rem 0 !important;
+    border-bottom: 1px solid var(--border) !important;
+}
+
+.pagefind-ui__result:last-child {
+    border-bottom: none !important;
+}
+
+.pagefind-ui__result-link {
+    color: var(--accent) !important;
+    text-decoration: none !important;
+}
+
+.pagefind-ui__result-link:hover {
+    text-decoration: underline !important;
+}
+
+.pagefind-ui__result-excerpt {
+    font-size: 0.8rem !important;
+    line-height: 1.4 !important;
+    color: var(--fg-muted) !important;
+    margin-top: 0.25rem !important;
+}
+
+.pagefind-ui__result-excerpt mark {
+    background: var(--accent) !important;
+    color: #000 !important;
+    padding: 0.1em 0.25em !important;
+    border-radius: 2px !important;
+}
+
+/* ============================================
+   Responsive
+   ============================================ */
+@media (max-width: 768px) {
+    .sidebar {
+        display: none;
+    }
+
+    .layout {
+        display: block;
+    }
+
+    .content {
+        padding: 1.5rem;
+        max-width: 100%;
+    }
+
+    .hero {
+        padding: 3rem 1.5rem;
+    }
+
+    .hero-title {
+        font-size: 2.5rem;
+    }
+
+    .hero-tagline {
+        font-size: 1.25rem;
+    }
+
     .site-nav {
-        padding: 1rem;
-        flex-wrap: wrap;
+        padding: 0.75rem 1rem;
     }
 
     .site-nav-search {
-        order: 3;
-        max-width: 100%;
-        width: 100%;
-        margin-top: 0.5rem;
-    }
-
-    .container {
-        padding: 2rem 1rem;
+        width: 180px;
     }
 
     article h1 {
-        font-size: 2rem;
+        font-size: 1.75rem;
     }
 }
-/* test 1764639560 */
-/* test2 1764639579 */

--- a/docs/templates/base.html
+++ b/docs/templates/base.html
@@ -4,12 +4,12 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}dodeca{% endblock title %}</title>
-    <meta name="description" content="A fully incremental static site generator">
+    <meta name="description" content="{% block description %}A fully incremental static site generator{% endblock description %}">
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <link rel="stylesheet" href="/css/style.css">
     <link rel="stylesheet" href="/pagefind/pagefind-ui.css">
 </head>
-<body>
+<body class="{% block body_class %}{% endblock body_class %}">
     <nav class="site-nav">
         <a href="/" class="site-nav-brand">
             <svg viewBox="0 0 64 64" width="28" height="28" class="site-nav-logo">
@@ -22,10 +22,7 @@
             </svg>
             <span>dodeca</span>
         </a>
-        <div class="site-nav-links">
-            <a href="/getting-started">Getting Started</a>
-            <a href="/features">Features</a>
-        </div>
+        <div class="site-nav-spacer"></div>
         <div id="search" class="site-nav-search"></div>
         <a href="https://github.com/bearcove/dodeca" class="site-nav-github" title="GitHub">
             <svg viewBox="0 0 16 16" width="24" height="24" fill="currentColor">
@@ -35,13 +32,33 @@
     </nav>
 
     {% block body %}
-    <main class="container">
-        {% block content %}{% endblock content %}
-    </main>
+    <div class="layout">
+        <aside class="sidebar">
+            <nav class="sidebar-nav">
+                {% for sub in root.subsections %}
+                <div class="sidebar-section">
+                    <h3><a href="{{ sub.permalink }}">{{ sub.title }}</a></h3>
+                    <ul>
+                        {% for page in sub.pages %}
+                        <li><a href="{{ page.permalink }}">{{ page.title }}</a></li>
+                        {% endfor %}
+                    </ul>
+                </div>
+                {% endfor %}
+            </nav>
+        </aside>
+        <main class="content">
+            {% block content %}{% endblock content %}
+        </main>
+    </div>
     {% endblock body %}
 
     <footer>
-        <p>Built with dodeca</p>
+        <p>
+            Made by <a href="https://fasterthanli.me">fasterthanlime</a>
+            · <a href="https://github.com/bearcove/dodeca">GitHub</a>
+            · Typeset in <a href="https://fonts.google.com/specimen/Public+Sans">Public Sans</a> & <a href="https://typeof.net/Iosevka/">Iosevka</a>
+        </p>
     </footer>
 
     <script src="/pagefind/pagefind-ui.js"></script>
@@ -52,7 +69,7 @@
             showSubResults: true,
             showImages: false,
             translations: {
-                placeholder: "Search ⌘K"
+                placeholder: "Search..."
             }
         });
 
@@ -68,6 +85,14 @@
                 e.preventDefault();
                 searchInput.focus();
                 searchInput.select();
+            }
+        });
+
+        // Highlight current page in sidebar
+        const currentPath = window.location.pathname;
+        document.querySelectorAll('.sidebar-nav a').forEach(link => {
+            if (link.getAttribute('href') === currentPath) {
+                link.classList.add('active');
             }
         });
     });

--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -1,9 +1,40 @@
 {% extends "base.html" %}
 
-{% block title %}{{ section.title }}{% endblock title %}
+{% block title %}dodeca - Incremental Static Sites{% endblock title %}
+{% block body_class %}home{% endblock body_class %}
 
-{% block content %}
-<article>
-    {{ section.content | safe }}
-</article>
-{% endblock content %}
+{% block body %}
+<div class="hero">
+    <div class="hero-content">
+        <h1 class="hero-title">dodeca</h1>
+        <p class="hero-tagline">Incremental static sites. Zero reloads.</p>
+        <p class="hero-sub">Built in Rust. Live-patched via WASM.</p>
+        <div class="hero-actions">
+            <a href="/guide/installation" class="btn btn-primary">Get Started</a>
+            <a href="https://github.com/bearcove/dodeca" class="btn btn-secondary">View on GitHub</a>
+        </div>
+    </div>
+</div>
+
+<div class="layout">
+    <aside class="sidebar">
+        <nav class="sidebar-nav">
+            {% for sub in root.subsections %}
+            <div class="sidebar-section">
+                <h3><a href="{{ sub.permalink }}">{{ sub.title }}</a></h3>
+                <ul>
+                    {% for page in sub.pages %}
+                    <li><a href="{{ page.permalink }}">{{ page.title }}</a></li>
+                    {% endfor %}
+                </ul>
+            </div>
+            {% endfor %}
+        </nav>
+    </aside>
+    <main class="content">
+        <article>
+            {{ section.content | safe }}
+        </article>
+    </main>
+</div>
+{% endblock body %}

--- a/src/html_diff.rs
+++ b/src/html_diff.rs
@@ -375,7 +375,7 @@ pub fn parse_html_fragment(html: &str) -> Option<DomNode> {
         .children
         .borrow()
         .iter()
-        .filter_map(|child| convert_rcdom_node(child))
+        .filter_map(convert_rcdom_node)
         .collect();
 
     if children.len() == 1 {
@@ -394,11 +394,10 @@ fn convert_rcdom_node(handle: &markup5ever_rcdom::Handle) -> Option<DomNode> {
             // Document node - return first element child (usually <html>)
             let children = handle.children.borrow();
             for child in children.iter() {
-                if let Some(node) = convert_rcdom_node(child) {
-                    if node.tag != "#text" {
+                if let Some(node) = convert_rcdom_node(child)
+                    && node.tag != "#text" {
                         return Some(node);
                     }
-                }
             }
             None
         }

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -1332,4 +1332,5 @@ weight = 10
         );
         assert_eq!(resolve_internal_link("/some/path/"), "/some/path/");
     }
+
 }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -843,7 +843,7 @@ async fn handle_livereload_socket(socket: WebSocket, server: Arc<SiteServer>) {
                     Ok(LiveReloadMsg::Patches { route, data }) => {
                         // Only send patches if client is viewing this route
                         // (or if we don't know their route yet, send anyway)
-                        if current_route.as_ref().map_or(true, |r| r == &route) {
+                        if current_route.as_ref().is_none_or(|r| r == &route) {
                             if sender.send(Message::Binary(data.into())).await.is_err() {
                                 break;
                             }

--- a/tests/fixtures/sample-site/.config/dodeca.kdl
+++ b/tests/fixtures/sample-site/.config/dodeca.kdl
@@ -2,3 +2,5 @@ content "content"
 output "public"
 link_check {
 }
+stable_assets {
+}

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -3,5 +3,6 @@ name = "xtask"
 version = "0.1.0"
 edition = "2024"
 rust-version = "1.91"
+publish = false
 
 [dependencies]


### PR DESCRIPTION
## Summary

- Add **plugcard** plugin system with serialized method calls across FFI boundary
- Restructure documentation website with sidebar navigation and separate pages
- Add incremental computation documentation

## Plugin System (plugcard)

- `plugcard` - Core types for dynamic library plugins
- `plugcard-macros` - `#[plugcard]` attribute macro using unsynn
- `dodeca-baseline` - Test plugin with `reverse_string` and `add` functions

## Website Changes

- Split monolithic homepage into separate pages (Features, Installation, Quick Start, Configuration)
- Add left sidebar navigation
- Add hero section on homepage
- Add documentation for incremental computation (Salsa queries)
- Add documentation for plugcard
- Add table styles
- Improve footer with credits

## Test plan

- [x] `cargo test -p dodeca-baseline` passes
- [x] Website builds and serves correctly
- [ ] Manual testing of all pages