### PR TITLE
feat: migrate plugcard to facet-postcard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1658,21 +1658,19 @@ dependencies = [
 name = "dodeca-jxl"
 version = "0.1.0"
 dependencies = [
+ "facet",
  "jpegxl-rs",
  "linkme",
  "plugcard",
- "postcard-schema",
- "serde",
 ]
 
 [[package]]
 name = "dodeca-webp"
 version = "0.1.0"
 dependencies = [
+ "facet",
  "linkme",
  "plugcard",
- "postcard-schema",
- "serde",
  "webp",
 ]
 
@@ -1790,7 +1788,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1878,6 +1876,16 @@ dependencies = [
  "quote",
  "strsim",
  "unsynn",
+]
+
+[[package]]
+name = "facet-postcard"
+version = "0.1.0"
+source = "git+https://github.com/facet-rs/facet#61d54e31dbae24d55872248ccd2b2a44136a841a"
+dependencies = [
+ "facet-core",
+ "facet-reflect",
+ "log",
 ]
 
 [[package]]
@@ -5255,12 +5263,11 @@ dependencies = [
 name = "plugcard"
 version = "0.1.0"
 dependencies = [
+ "facet",
+ "facet-postcard",
  "libloading",
  "linkme",
  "plugcard-macros",
- "postcard",
- "postcard-schema",
- "serde",
 ]
 
 [[package]]
@@ -5553,7 +5560,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.1",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6020,7 +6027,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6768,7 +6775,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7796,7 +7803,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ salsa = { version = "0.24", features = ["persistence"] }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
-postcard = "1"             # Fast, compact binary serialization with serde
+postcard = { version = "1", features = ["alloc"] }  # Fast, compact binary serialization with serde
 
 # Content-addressed storage
 rapidhash = "4"

--- a/crates/dodeca-jxl/Cargo.toml
+++ b/crates/dodeca-jxl/Cargo.toml
@@ -12,9 +12,8 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 plugcard = { path = "../plugcard" }
+facet = { git = "https://github.com/facet-rs/facet" }
 linkme = "0.3"
-postcard-schema = { version = "0.1", features = ["derive", "alloc"] }
-serde = { version = "1", features = ["derive"] }
 
 # JPEG XL encoding
 jpegxl-rs = { version = "0.11", features = ["vendored"] }

--- a/crates/dodeca-jxl/src/lib.rs
+++ b/crates/dodeca-jxl/src/lib.rs
@@ -1,12 +1,13 @@
 //! JPEG XL encoding and decoding plugin for dodeca
 
+use facet::Facet;
 use jpegxl_rs::encode::EncoderFrame;
-use plugcard::plugcard;
+use plugcard::{plugcard, PlugResult};
 
 plugcard::export_plugin!();
 
 /// Decoded image data
-#[derive(serde::Serialize, serde::Deserialize, postcard_schema::Schema)]
+#[derive(Facet)]
 pub struct DecodedImage {
     pub pixels: Vec<u8>,
     pub width: u32,
@@ -16,16 +17,18 @@ pub struct DecodedImage {
 
 /// Decode JPEG XL to RGBA pixels
 #[plugcard]
-pub fn decode_jxl(data: Vec<u8>) -> Result<DecodedImage, String> {
-    let decoder = jpegxl_rs::decoder_builder()
-        .build()
-        .map_err(|e| format!("Failed to create JXL decoder: {e}"))?;
+pub fn decode_jxl(data: Vec<u8>) -> PlugResult<DecodedImage> {
+    let decoder = match jpegxl_rs::decoder_builder().build() {
+        Ok(d) => d,
+        Err(e) => return PlugResult::Err(format!("Failed to create JXL decoder: {e}")),
+    };
 
-    let (metadata, pixels) = decoder
-        .decode_with::<u8>(&data)
-        .map_err(|e| format!("Failed to decode JXL: {e}"))?;
+    let (metadata, pixels) = match decoder.decode_with::<u8>(&data) {
+        Ok(result) => result,
+        Err(e) => return PlugResult::Err(format!("Failed to decode JXL: {e}")),
+    };
 
-    Ok(DecodedImage {
+    PlugResult::Ok(DecodedImage {
         pixels,
         width: metadata.width,
         height: metadata.height,
@@ -35,9 +38,9 @@ pub fn decode_jxl(data: Vec<u8>) -> Result<DecodedImage, String> {
 
 /// Encode RGBA pixels to JPEG XL
 #[plugcard]
-pub fn encode_jxl(pixels: Vec<u8>, width: u32, height: u32, quality: u8) -> Result<Vec<u8>, String> {
+pub fn encode_jxl(pixels: Vec<u8>, width: u32, height: u32, quality: u8) -> PlugResult<Vec<u8>> {
     if pixels.len() != (width * height * 4) as usize {
-        return Err(format!(
+        return PlugResult::Err(format!(
             "Expected {} bytes for {}x{} RGBA, got {}",
             width * height * 4,
             width,
@@ -52,18 +55,22 @@ pub fn encode_jxl(pixels: Vec<u8>, width: u32, height: u32, quality: u8) -> Resu
     // quality 0 -> distance ~15 (low quality)
     let distance = (100.0 - quality as f32) / 100.0 * 15.0;
 
-    let mut encoder = jpegxl_rs::encoder_builder()
+    let mut encoder = match jpegxl_rs::encoder_builder()
         .quality(distance.max(0.1)) // quality() is actually distance in jpegxl-rs
         .build()
-        .map_err(|e| format!("Failed to create JXL encoder: {e}"))?;
+    {
+        Ok(e) => e,
+        Err(e) => return PlugResult::Err(format!("Failed to create JXL encoder: {e}")),
+    };
 
     encoder.has_alpha = true;
     let frame = EncoderFrame::new(&pixels).num_channels(4);
-    let result = encoder
-        .encode_frame::<_, u8>(&frame, width, height)
-        .map_err(|e| format!("Failed to encode JXL: {e}"))?;
+    let result = match encoder.encode_frame::<_, u8>(&frame, width, height) {
+        Ok(r) => r,
+        Err(e) => return PlugResult::Err(format!("Failed to encode JXL: {e}")),
+    };
 
-    Ok(result.data.to_vec())
+    PlugResult::Ok(result.data.to_vec())
 }
 
 #[cfg(test)]
@@ -75,16 +82,19 @@ mod tests {
         // 16x16 red pixels (RGBA) - JXL encoder needs larger images
         let pixels = vec![255u8, 0, 0, 255].repeat(16 * 16);
 
-        let result = encode_jxl(pixels, 16, 16, 80).unwrap();
-        assert!(!result.is_empty());
+        let result = encode_jxl(pixels, 16, 16, 80);
+        let PlugResult::Ok(data) = result else {
+            panic!("Expected Ok, got Err");
+        };
+        assert!(!data.is_empty());
         // JXL magic: 0xff 0x0a for naked codestream
-        assert_eq!(&result[0..2], &[0xff, 0x0a]);
+        assert_eq!(&data[0..2], &[0xff, 0x0a]);
     }
 
     #[test]
     fn test_wrong_size() {
         let pixels = vec![255, 0, 0, 255];
         let result = encode_jxl(pixels, 2, 2, 80);
-        assert!(result.is_err());
+        assert!(matches!(result, PlugResult::Err(_)));
     }
 }

--- a/crates/dodeca-webp/Cargo.toml
+++ b/crates/dodeca-webp/Cargo.toml
@@ -12,9 +12,8 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 plugcard = { path = "../plugcard" }
+facet = { git = "https://github.com/facet-rs/facet" }
 linkme = "0.3"
-postcard-schema = { version = "0.1", features = ["derive", "alloc"] }
-serde = { version = "1", features = ["derive"] }
 
 # WebP encoding
 webp = "0.3"

--- a/crates/plugcard/Cargo.toml
+++ b/crates/plugcard/Cargo.toml
@@ -11,12 +11,9 @@ keywords = ["plugin", "ffi", "dynamic-library", "rpc"]
 categories = ["development-tools", "rust-patterns"]
 
 [dependencies]
-# Serialization
-postcard = { version = "1", features = ["alloc"] }
-serde = { version = "1", features = ["derive"] }
-
-# Schema introspection
-postcard-schema = { version = "0.1", features = ["derive", "alloc"] }
+# Serialization via facet (replacing serde + postcard)
+facet = { git = "https://github.com/facet-rs/facet" }
+facet-postcard = { git = "https://github.com/facet-rs/facet", features = ["alloc"] }
 
 # Distributed slices for method registration
 linkme = "0.3"


### PR DESCRIPTION
## Summary

- Replace postcard + serde + postcard-schema with facet + facet-postcard for plugin serialization
- Add `PlugResult<T>` as a Facet-compatible replacement for `Result<T, String>` (std Result doesn't implement Facet)
- Update plugin functions to return `PlugResult` instead of `Result`
- Update macro to use `facet_postcard` for serialization/deserialization
- Update caller-side code in dodeca to use Facet derives

## Test plan

- [x] All existing tests pass
- [x] Clippy passes
- [x] Build succeeds

Closes #17