### PR TITLE
feat: expose last_updated timestamp to templates

### DIFF
--- a/docs/content/internals/templates.md
+++ b/docs/content/internals/templates.md
@@ -18,7 +18,7 @@ dodeca includes a Jinja-like template engine built for tight integration with Sa
 {% endblock %}
 ```
 
-Templates receive `page` (title, content, permalink, path, weight, toc, ancestors), `section` (title, content, pages, subsections), and `config`.
+Templates receive `page` (title, content, permalink, path, weight, toc, ancestors, last_updated), `section` (title, content, pages, subsections, last_updated), and `config`.
 
 The `ancestors` field is an ordered list of parent sections from root to immediate parent, useful for breadcrumbs:
 
@@ -27,6 +27,12 @@ The `ancestors` field is an ordered list of parent sections from root to immedia
   <a href="{{ ancestor.permalink }}">{{ ancestor.title }}</a> /
 {% endfor %}
 {{ page.title }}
+```
+
+The `last_updated` field is a Unix timestamp (seconds since epoch) of the source file's modification time, useful for "last updated" notices:
+
+```jinja
+Last updated: {{ page.last_updated }}
 ```
 
 Filters: `safe` (no escaping), `upper`, `lower`, `trim`, `default(value)`.

--- a/src/db.rs
+++ b/src/db.rs
@@ -99,6 +99,9 @@ pub struct SourceFile {
     /// The raw content of the file
     #[returns(ref)]
     pub content: SourceContent,
+
+    /// Last modification time as Unix timestamp (seconds since epoch)
+    pub last_modified: i64,
 }
 
 /// Input: A template file with its content
@@ -212,6 +215,8 @@ pub struct Section {
     pub body_html: HtmlBody,
     /// Headings extracted from content
     pub headings: Vec<Heading>,
+    /// Last modification time as Unix timestamp (seconds since epoch)
+    pub last_updated: i64,
 }
 
 /// A page in the site tree (non-index .md files)
@@ -224,6 +229,8 @@ pub struct Page {
     pub section_route: Route,
     /// Headings extracted from content
     pub headings: Vec<Heading>,
+    /// Last modification time as Unix timestamp (seconds since epoch)
+    pub last_updated: i64,
 }
 
 /// The complete site tree - sections and pages
@@ -254,6 +261,8 @@ pub struct ParsedData {
     pub is_section: bool,
     /// Headings extracted from content
     pub headings: Vec<Heading>,
+    /// Last modification time as Unix timestamp (seconds since epoch)
+    pub last_updated: i64,
 }
 
 /// A single output file to be written to disk

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -161,6 +161,7 @@ pub struct Frontmatter {
 pub fn parse_file(db: &dyn Db, source: SourceFile) -> ParsedData {
     let content = source.content(db);
     let path = source.path(db);
+    let last_modified = source.last_modified(db);
 
     // Split frontmatter and body
     let (frontmatter_str, markdown) = split_frontmatter(content.as_str());
@@ -198,6 +199,7 @@ pub fn parse_file(db: &dyn Db, source: SourceFile) -> ParsedData {
         body_html,
         is_section,
         headings,
+        last_updated: last_modified,
     }
 }
 
@@ -225,6 +227,7 @@ pub fn build_tree<'db>(db: &'db dyn Db, sources: SourceRegistry<'db>) -> SiteTre
                 weight: data.weight,
                 body_html: data.body_html.clone(),
                 headings: data.headings.clone(),
+                last_updated: data.last_updated,
             },
         );
     }
@@ -236,6 +239,7 @@ pub fn build_tree<'db>(db: &'db dyn Db, sources: SourceRegistry<'db>) -> SiteTre
         weight: 0,
         body_html: HtmlBody::from_static(""),
         headings: Vec::new(),
+        last_updated: 0,
     });
 
     // Second pass: create pages and assign to sections
@@ -250,6 +254,7 @@ pub fn build_tree<'db>(db: &'db dyn Db, sources: SourceRegistry<'db>) -> SiteTre
                 body_html: data.body_html.clone(),
                 section_route,
                 headings: data.headings.clone(),
+                last_updated: data.last_updated,
             },
         );
     }

--- a/src/render.rs
+++ b/src/render.rs
@@ -643,6 +643,10 @@ fn page_to_value(page: &Page, site_tree: &SiteTree) -> Value {
         "ancestors".to_string(),
         Value::List(build_ancestors(&page.section_route, site_tree)),
     );
+    map.insert(
+        "last_updated".to_string(),
+        Value::Int(page.last_updated),
+    );
     Value::Dict(map)
 }
 
@@ -666,6 +670,10 @@ fn section_to_value(section: &Section, site_tree: &SiteTree) -> Value {
         Value::String(route_to_path(section.route.as_str())),
     );
     map.insert("weight".to_string(), Value::Int(section.weight as i64));
+    map.insert(
+        "last_updated".to_string(),
+        Value::Int(section.last_updated),
+    );
 
     // Add pages in this section (sorted by weight, including their headings)
     let mut pages: Vec<&Page> = site_tree


### PR DESCRIPTION
## Summary

- Add `last_updated` field to pages and sections, derived from the source `.md` file's modification time
- Enables "last updated" notices in templates without requiring manual frontmatter maintenance
- The timestamp is a Unix timestamp (seconds since epoch) exposed as an integer

## Template Usage

```jinja
Last updated: {{ page.last_updated }}
```

## Implementation

- Added `last_modified` field to `SourceFile` (Salsa input)
- Propagated through `ParsedData` → `Page`/`Section` → template context
- Updated all file loading paths to capture mtime via `fs::metadata()`

## Test plan

- [x] Build passes
- [x] Unit tests pass
- [ ] Manual verification with a test site