### PR TITLE
feat: add benchmarks for critical paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,6 +153,18 @@ futures = "0.3"        # For StreamExt in browser tests
 name = "html_diff"
 harness = false
 
+[[bench]]
+name = "link_checker"
+harness = false
+
+[[bench]]
+name = "ansi_to_html"
+harness = false
+
+[[bench]]
+name = "template"
+harness = false
+
 # Optimize dependencies in dev mode for faster tests
 # (keeps main crate unoptimized for fast incremental builds)
 [profile.dev.package."*"]

--- a/benches/ansi_to_html.rs
+++ b/benches/ansi_to_html.rs
@@ -1,0 +1,167 @@
+//! Benchmarks for ANSI to HTML conversion
+//!
+//! Run with: cargo bench --bench ansi_to_html
+
+use divan::{black_box, Bencher};
+use dodeca::error_pages::ansi_to_html;
+
+fn main() {
+    divan::main();
+}
+
+// ============================================================================
+// Test data generators
+// ============================================================================
+
+/// Plain text without any ANSI codes
+fn generate_plain_text(lines: usize) -> String {
+    (0..lines)
+        .map(|i| format!("This is line {} of plain text without any formatting.\n", i))
+        .collect()
+}
+
+/// Text with basic ANSI formatting (bold, colors)
+fn generate_basic_ansi(lines: usize) -> String {
+    (0..lines)
+        .map(|i| {
+            format!(
+                "\x1b[1mBold line {}\x1b[0m: \x1b[31mred\x1b[0m \x1b[32mgreen\x1b[0m \x1b[34mblue\x1b[0m\n",
+                i
+            )
+        })
+        .collect()
+}
+
+/// Simulated compiler error output with complex formatting
+fn generate_compiler_error() -> String {
+    r#"
+error[E0382]: borrow of moved value: `data`
+   --> src/main.rs:15:20
+    |
+12  |     let data = vec![1, 2, 3];
+    |         ---- move occurs because `data` has type `Vec<i32>`, which does not implement the `Copy` trait
+13  |     let result = process(data);
+    |                          ---- value moved here
+14  |
+15  |     println!("{:?}", data);
+    |                      ^^^^ value borrowed here after move
+    |
+note: consider cloning the value if the performance cost is acceptable
+   --> src/main.rs:13:26
+    |
+13  |     let result = process(data);
+    |                          ^^^^
+help: consider cloning the value
+    |
+13  |     let result = process(data.clone());
+    |                              ++++++++
+
+For more information about this error, try `rustc --explain E0382`.
+"#.replace("error", "\x1b[1;31merror\x1b[0m")
+     .replace("-->", "\x1b[34m-->\x1b[0m")
+     .replace("note:", "\x1b[1;36mnote:\x1b[0m")
+     .replace("help:", "\x1b[1;32mhelp:\x1b[0m")
+     .replace("^^^^", "\x1b[1;31m^^^^\x1b[0m")
+     .replace("----", "\x1b[34m----\x1b[0m")
+}
+
+/// Text with 24-bit RGB colors
+fn generate_rgb_colors(lines: usize) -> String {
+    (0..lines)
+        .map(|i| {
+            let r = (i * 10) % 256;
+            let g = (i * 20) % 256;
+            let b = (i * 30) % 256;
+            format!(
+                "\x1b[38;2;{};{};{}mLine {} with RGB color ({}, {}, {})\x1b[0m\n",
+                r, g, b, i, r, g, b
+            )
+        })
+        .collect()
+}
+
+/// Deeply nested formatting (multiple attributes)
+fn generate_nested_formatting(lines: usize) -> String {
+    (0..lines)
+        .map(|i| {
+            format!(
+                "\x1b[1m\x1b[4m\x1b[31mBold underline red line {}\x1b[0m normal \x1b[2m\x1b[3mdim italic\x1b[0m\n",
+                i
+            )
+        })
+        .collect()
+}
+
+// ============================================================================
+// Benchmarks
+// ============================================================================
+
+#[divan::bench]
+fn plain_text_small(bencher: Bencher) {
+    let input = generate_plain_text(10);
+    bencher.bench(|| black_box(ansi_to_html(black_box(&input))));
+}
+
+#[divan::bench]
+fn plain_text_large(bencher: Bencher) {
+    let input = generate_plain_text(1000);
+    bencher.bench(|| black_box(ansi_to_html(black_box(&input))));
+}
+
+#[divan::bench]
+fn basic_ansi_small(bencher: Bencher) {
+    let input = generate_basic_ansi(10);
+    bencher.bench(|| black_box(ansi_to_html(black_box(&input))));
+}
+
+#[divan::bench]
+fn basic_ansi_large(bencher: Bencher) {
+    let input = generate_basic_ansi(1000);
+    bencher.bench(|| black_box(ansi_to_html(black_box(&input))));
+}
+
+#[divan::bench]
+fn compiler_error(bencher: Bencher) {
+    let input = generate_compiler_error();
+    bencher.bench(|| black_box(ansi_to_html(black_box(&input))));
+}
+
+#[divan::bench]
+fn rgb_colors_small(bencher: Bencher) {
+    let input = generate_rgb_colors(10);
+    bencher.bench(|| black_box(ansi_to_html(black_box(&input))));
+}
+
+#[divan::bench]
+fn rgb_colors_large(bencher: Bencher) {
+    let input = generate_rgb_colors(500);
+    bencher.bench(|| black_box(ansi_to_html(black_box(&input))));
+}
+
+#[divan::bench]
+fn nested_formatting_small(bencher: Bencher) {
+    let input = generate_nested_formatting(10);
+    bencher.bench(|| black_box(ansi_to_html(black_box(&input))));
+}
+
+#[divan::bench]
+fn nested_formatting_large(bencher: Bencher) {
+    let input = generate_nested_formatting(500);
+    bencher.bench(|| black_box(ansi_to_html(black_box(&input))));
+}
+
+// ============================================================================
+// Throughput benchmarks
+// ============================================================================
+
+#[divan::bench(args = [1024, 10240, 102400])]
+fn throughput_bytes(bencher: Bencher, size: usize) {
+    // Generate text of approximately the given size
+    let line = "\x1b[31mError:\x1b[0m Something went \x1b[1mwrong\x1b[0m at line 42\n";
+    let repetitions = size / line.len() + 1;
+    let input: String = std::iter::repeat(line).take(repetitions).collect();
+
+    bencher
+        .counter(divan::counter::BytesCount::new(input.len()))
+        .bench(|| black_box(ansi_to_html(black_box(&input))));
+}

--- a/benches/link_checker.rs
+++ b/benches/link_checker.rs
@@ -1,0 +1,210 @@
+//! Benchmarks for link checking
+//!
+//! Run with: cargo bench --bench link_checker
+
+use divan::{black_box, Bencher};
+use dodeca::link_checker::{extract_links, check_internal_links, Page};
+use dodeca::types::Route;
+
+fn main() {
+    divan::main();
+}
+
+// ============================================================================
+// HTML generators for link checking
+// ============================================================================
+
+/// Generate HTML for a page with many internal links
+fn generate_page_with_links(num_links: usize, page_id: usize) -> String {
+    let mut html = String::from("<!DOCTYPE html><html><head><title>Test</title></head><body>");
+    html.push_str("<nav>");
+
+    // Add navigation links
+    for i in 0..10 {
+        html.push_str(&format!(r#"<a href="/page/{}"">Page {}</a>"#, i, i));
+    }
+    html.push_str("</nav>");
+
+    html.push_str("<main>");
+    // Add content links
+    for i in 0..num_links {
+        let target = (page_id + i) % 100; // Create links to various pages
+        html.push_str(&format!(
+            r#"<p>This is paragraph {} with a <a href="/page/{}">link to page {}</a> and some text.</p>"#,
+            i, target, target
+        ));
+
+        // Add some external links too
+        if i % 5 == 0 {
+            html.push_str(&format!(
+                r#"<p>Check out <a href="https://example.com/resource/{}">this external resource</a>.</p>"#,
+                i
+            ));
+        }
+    }
+    html.push_str("</main>");
+
+    html.push_str("</body></html>");
+    html
+}
+
+/// Generate a small site (10 pages)
+fn generate_small_site() -> Vec<(String, String)> {
+    (0..10)
+        .map(|i| {
+            let route = format!("/page/{}", i);
+            let html = generate_page_with_links(20, i);
+            (route, html)
+        })
+        .collect()
+}
+
+/// Generate a medium site (100 pages)
+fn generate_medium_site() -> Vec<(String, String)> {
+    (0..100)
+        .map(|i| {
+            let route = format!("/page/{}", i);
+            let html = generate_page_with_links(50, i);
+            (route, html)
+        })
+        .collect()
+}
+
+/// Generate a large site (1000 pages)
+fn generate_large_site() -> Vec<(String, String)> {
+    (0..1000)
+        .map(|i| {
+            let route = format!("/page/{}", i);
+            let html = generate_page_with_links(30, i);
+            (route, html)
+        })
+        .collect()
+}
+
+// ============================================================================
+// Link extraction benchmarks
+// ============================================================================
+
+/// Helper struct to hold route and html together with proper lifetimes
+struct SitePage {
+    route: Route,
+    html: String,
+}
+
+#[divan::bench]
+fn extract_links_small_site(bencher: Bencher) {
+    let site: Vec<SitePage> = generate_small_site()
+        .into_iter()
+        .map(|(route, html)| SitePage {
+            route: Route::from(route),
+            html,
+        })
+        .collect();
+
+    bencher.bench(|| {
+        let pages_iter = site.iter().map(|p| Page {
+            route: &p.route,
+            html: &p.html,
+        });
+        black_box(extract_links(pages_iter))
+    });
+}
+
+#[divan::bench]
+fn extract_links_medium_site(bencher: Bencher) {
+    let site: Vec<SitePage> = generate_medium_site()
+        .into_iter()
+        .map(|(route, html)| SitePage {
+            route: Route::from(route),
+            html,
+        })
+        .collect();
+
+    bencher.bench(|| {
+        let pages_iter = site.iter().map(|p| Page {
+            route: &p.route,
+            html: &p.html,
+        });
+        black_box(extract_links(pages_iter))
+    });
+}
+
+#[divan::bench]
+fn extract_links_large_site(bencher: Bencher) {
+    let site: Vec<SitePage> = generate_large_site()
+        .into_iter()
+        .map(|(route, html)| SitePage {
+            route: Route::from(route),
+            html,
+        })
+        .collect();
+
+    bencher.bench(|| {
+        let pages_iter = site.iter().map(|p| Page {
+            route: &p.route,
+            html: &p.html,
+        });
+        black_box(extract_links(pages_iter))
+    });
+}
+
+// ============================================================================
+// Internal link checking benchmarks
+// ============================================================================
+
+#[divan::bench]
+fn check_internal_small_site(bencher: Bencher) {
+    let site: Vec<SitePage> = generate_small_site()
+        .into_iter()
+        .map(|(route, html)| SitePage {
+            route: Route::from(route),
+            html,
+        })
+        .collect();
+
+    let pages_iter = site.iter().map(|p| Page {
+        route: &p.route,
+        html: &p.html,
+    });
+    let extracted = extract_links(pages_iter);
+
+    bencher.bench(|| black_box(check_internal_links(&extracted)));
+}
+
+#[divan::bench]
+fn check_internal_medium_site(bencher: Bencher) {
+    let site: Vec<SitePage> = generate_medium_site()
+        .into_iter()
+        .map(|(route, html)| SitePage {
+            route: Route::from(route),
+            html,
+        })
+        .collect();
+
+    let pages_iter = site.iter().map(|p| Page {
+        route: &p.route,
+        html: &p.html,
+    });
+    let extracted = extract_links(pages_iter);
+
+    bencher.bench(|| black_box(check_internal_links(&extracted)));
+}
+
+#[divan::bench]
+fn check_internal_large_site(bencher: Bencher) {
+    let site: Vec<SitePage> = generate_large_site()
+        .into_iter()
+        .map(|(route, html)| SitePage {
+            route: Route::from(route),
+            html,
+        })
+        .collect();
+
+    let pages_iter = site.iter().map(|p| Page {
+        route: &p.route,
+        html: &p.html,
+    });
+    let extracted = extract_links(pages_iter);
+
+    bencher.bench(|| black_box(check_internal_links(&extracted)));
+}

--- a/benches/template.rs
+++ b/benches/template.rs
@@ -1,0 +1,399 @@
+//! Benchmarks for template engine
+//!
+//! Run with: cargo bench --bench template
+//!
+//! Benchmarks cover:
+//! - Lexing (tokenization)
+//! - Parsing (AST generation)
+//! - Full render (parse + evaluate)
+
+use divan::{black_box, Bencher};
+use dodeca::template::{Context, Engine, InMemoryLoader, Value};
+use dodeca::template::lexer::Lexer;
+use dodeca::template::parser::Parser;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+fn main() {
+    divan::main();
+}
+
+// ============================================================================
+// Template generators
+// ============================================================================
+
+/// Simple template with just text
+fn simple_text() -> &'static str {
+    "Hello, World! This is a simple static text template."
+}
+
+/// Template with variable interpolation
+fn with_variables() -> &'static str {
+    r#"Hello, {{ name }}! Welcome to {{ site_name }}.
+Your account was created on {{ created_date }}.
+You have {{ message_count }} unread messages."#
+}
+
+/// Template with loops
+fn with_loops() -> &'static str {
+    r#"<ul>
+{% for item in items %}
+  <li>{{ item.name }}: {{ item.price }}</li>
+{% endfor %}
+</ul>"#
+}
+
+/// Template with conditionals
+fn with_conditionals() -> &'static str {
+    r#"{% if user.is_admin %}
+  <div class="admin-panel">Admin Controls</div>
+{% elif user.is_moderator %}
+  <div class="mod-panel">Moderator Controls</div>
+{% else %}
+  <div class="user-panel">User Controls</div>
+{% endif %}"#
+}
+
+/// Template with filters
+fn with_filters() -> &'static str {
+    r#"{{ title | upper }}
+{{ description | lower }}
+{{ content | safe }}
+{{ number | default(0) }}"#
+}
+
+/// Complex realistic template (like a blog post layout)
+fn complex_template() -> &'static str {
+    r#"<!DOCTYPE html>
+<html>
+<head>
+    <title>{{ page.title }} - {{ site.name }}</title>
+    <meta charset="utf-8">
+</head>
+<body>
+    <header>
+        <nav>
+            {% for link in nav_links %}
+            <a href="{{ link.url }}"{% if link.active %} class="active"{% endif %}>{{ link.label }}</a>
+            {% endfor %}
+        </nav>
+    </header>
+
+    <main>
+        <article>
+            <h1>{{ page.title }}</h1>
+            <div class="meta">
+                Published on {{ page.date }}
+                {% if page.author %}by {{ page.author }}{% endif %}
+            </div>
+            <div class="content">
+                {{ page.content | safe }}
+            </div>
+            {% if page.tags %}
+            <div class="tags">
+                {% for tag in page.tags %}
+                <span class="tag">{{ tag }}</span>
+                {% endfor %}
+            </div>
+            {% endif %}
+        </article>
+
+        {% if related_posts %}
+        <aside class="related">
+            <h2>Related Posts</h2>
+            <ul>
+            {% for post in related_posts %}
+                <li><a href="{{ post.url }}">{{ post.title }}</a></li>
+            {% endfor %}
+            </ul>
+        </aside>
+        {% endif %}
+    </main>
+
+    <footer>
+        <p>&copy; {{ site.year }} {{ site.name }}</p>
+    </footer>
+</body>
+</html>"#
+}
+
+/// Generate a template with many loop iterations
+fn large_loop_template(iterations: usize) -> String {
+    format!(
+        r#"<ul>
+{{% for i in range({}) %}}
+<li>Item {{{{ i }}}}: Some content here with value {{{{ i * 2 }}}}</li>
+{{% endfor %}}
+</ul>"#,
+        iterations
+    )
+}
+
+// ============================================================================
+// Context builders
+// ============================================================================
+
+fn simple_context() -> Context {
+    let mut ctx = Context::new();
+    ctx.set("name", Value::String("Alice".into()));
+    ctx.set("site_name", Value::String("My Site".into()));
+    ctx.set("created_date", Value::String("2024-01-15".into()));
+    ctx.set("message_count", Value::Int(42));
+    ctx
+}
+
+fn loop_context() -> Context {
+    let mut ctx = Context::new();
+    let items: Vec<Value> = (0..10)
+        .map(|i| {
+            let mut item = HashMap::new();
+            item.insert("name".to_string(), Value::String(format!("Item {}", i)));
+            item.insert("price".to_string(), Value::Float(i as f64 * 9.99));
+            Value::Dict(item)
+        })
+        .collect();
+    ctx.set("items", Value::List(items));
+    ctx
+}
+
+fn complex_context() -> Context {
+    let mut ctx = Context::new();
+
+    // Page data
+    let mut page = HashMap::new();
+    page.insert("title".to_string(), Value::String("My Blog Post".into()));
+    page.insert("date".to_string(), Value::String("2024-03-15".into()));
+    page.insert(
+        "author".to_string(),
+        Value::String("John Doe".into()),
+    );
+    page.insert(
+        "content".to_string(),
+        Value::String("<p>This is the post content with <strong>HTML</strong>.</p>".into()),
+    );
+    page.insert(
+        "tags".to_string(),
+        Value::List(vec![
+            Value::String("rust".into()),
+            Value::String("programming".into()),
+            Value::String("web".into()),
+        ]),
+    );
+    ctx.set("page", Value::Dict(page));
+
+    // Site data
+    let mut site = HashMap::new();
+    site.insert("name".to_string(), Value::String("My Blog".into()));
+    site.insert("year".to_string(), Value::Int(2024));
+    ctx.set("site", Value::Dict(site));
+
+    // Navigation
+    let nav_links: Vec<Value> = vec![
+        {
+            let mut link = HashMap::new();
+            link.insert("url".to_string(), Value::String("/".into()));
+            link.insert("label".to_string(), Value::String("Home".into()));
+            link.insert("active".to_string(), Value::Bool(false));
+            Value::Dict(link)
+        },
+        {
+            let mut link = HashMap::new();
+            link.insert("url".to_string(), Value::String("/blog".into()));
+            link.insert("label".to_string(), Value::String("Blog".into()));
+            link.insert("active".to_string(), Value::Bool(true));
+            Value::Dict(link)
+        },
+        {
+            let mut link = HashMap::new();
+            link.insert("url".to_string(), Value::String("/about".into()));
+            link.insert("label".to_string(), Value::String("About".into()));
+            link.insert("active".to_string(), Value::Bool(false));
+            Value::Dict(link)
+        },
+    ];
+    ctx.set("nav_links", Value::List(nav_links));
+
+    // Related posts
+    let related_posts: Vec<Value> = (0..3)
+        .map(|i| {
+            let mut post = HashMap::new();
+            post.insert(
+                "url".to_string(),
+                Value::String(format!("/posts/related-{}", i)),
+            );
+            post.insert(
+                "title".to_string(),
+                Value::String(format!("Related Post {}", i + 1)),
+            );
+            Value::Dict(post)
+        })
+        .collect();
+    ctx.set("related_posts", Value::List(related_posts));
+
+    ctx
+}
+
+// ============================================================================
+// Lexer benchmarks
+// ============================================================================
+
+#[divan::bench]
+fn lex_simple(bencher: Bencher) {
+    let source = simple_text();
+    bencher.bench(|| {
+        let lexer = Lexer::new(Arc::new(black_box(source).to_string()));
+        for _ in lexer {}
+    });
+}
+
+#[divan::bench]
+fn lex_with_variables(bencher: Bencher) {
+    let source = with_variables();
+    bencher.bench(|| {
+        let lexer = Lexer::new(Arc::new(black_box(source).to_string()));
+        for _ in lexer {}
+    });
+}
+
+#[divan::bench]
+fn lex_complex(bencher: Bencher) {
+    let source = complex_template();
+    bencher.bench(|| {
+        let lexer = Lexer::new(Arc::new(black_box(source).to_string()));
+        for _ in lexer {}
+    });
+}
+
+// ============================================================================
+// Parser benchmarks
+// ============================================================================
+
+#[divan::bench]
+fn parse_simple(bencher: Bencher) {
+    let source = simple_text();
+    bencher.bench(|| {
+        let parser = Parser::new("bench", black_box(source));
+        black_box(parser.parse())
+    });
+}
+
+#[divan::bench]
+fn parse_with_variables(bencher: Bencher) {
+    let source = with_variables();
+    bencher.bench(|| {
+        let parser = Parser::new("bench", black_box(source));
+        black_box(parser.parse())
+    });
+}
+
+#[divan::bench]
+fn parse_with_loops(bencher: Bencher) {
+    let source = with_loops();
+    bencher.bench(|| {
+        let parser = Parser::new("bench", black_box(source));
+        black_box(parser.parse())
+    });
+}
+
+#[divan::bench]
+fn parse_with_conditionals(bencher: Bencher) {
+    let source = with_conditionals();
+    bencher.bench(|| {
+        let parser = Parser::new("bench", black_box(source));
+        black_box(parser.parse())
+    });
+}
+
+#[divan::bench]
+fn parse_complex(bencher: Bencher) {
+    let source = complex_template();
+    bencher.bench(|| {
+        let parser = Parser::new("bench", black_box(source));
+        black_box(parser.parse())
+    });
+}
+
+// ============================================================================
+// Full render benchmarks
+// ============================================================================
+
+#[divan::bench]
+fn render_simple(bencher: Bencher) {
+    let source = simple_text();
+    let ctx = Context::new();
+
+    bencher.bench(|| {
+        let mut loader = InMemoryLoader::new();
+        loader.add("bench", source);
+        let mut engine = Engine::new(loader);
+        black_box(engine.render("bench", &ctx))
+    });
+}
+
+#[divan::bench]
+fn render_with_variables(bencher: Bencher) {
+    let source = with_variables();
+    let ctx = simple_context();
+
+    bencher.bench(|| {
+        let mut loader = InMemoryLoader::new();
+        loader.add("bench", source);
+        let mut engine = Engine::new(loader);
+        black_box(engine.render("bench", &ctx))
+    });
+}
+
+#[divan::bench]
+fn render_with_loops(bencher: Bencher) {
+    let source = with_loops();
+    let ctx = loop_context();
+
+    bencher.bench(|| {
+        let mut loader = InMemoryLoader::new();
+        loader.add("bench", source);
+        let mut engine = Engine::new(loader);
+        black_box(engine.render("bench", &ctx))
+    });
+}
+
+#[divan::bench]
+fn render_complex(bencher: Bencher) {
+    let source = complex_template();
+    let ctx = complex_context();
+
+    bencher.bench(|| {
+        let mut loader = InMemoryLoader::new();
+        loader.add("bench", source);
+        let mut engine = Engine::new(loader);
+        black_box(engine.render("bench", &ctx))
+    });
+}
+
+// ============================================================================
+// Scaling benchmarks
+// ============================================================================
+
+#[divan::bench(args = [10, 100, 1000])]
+fn render_loop_scaling(bencher: Bencher, iterations: usize) {
+    let source = large_loop_template(iterations);
+
+    // Create context with range function
+    let mut ctx = Context::new();
+    ctx.register_fn(
+        "range",
+        Box::new(move |args: &[Value], _kwargs: &[(String, Value)]| {
+            let n = match args.first() {
+                Some(Value::Int(n)) => *n as usize,
+                _ => 0,
+            };
+            Ok(Value::List((0..n).map(|i| Value::Int(i as i64)).collect()))
+        }),
+    );
+
+    bencher.bench(|| {
+        let mut loader = InMemoryLoader::new();
+        loader.add("bench", &source);
+        let mut engine = Engine::new(loader);
+        black_box(engine.render("bench", &ctx))
+    });
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,4 +2,9 @@
 //!
 //! This module exposes internal components for benchmarking and testing.
 
+pub mod db;
+pub mod error_pages;
 pub mod html_diff;
+pub mod link_checker;
+pub mod template;
+pub mod types;

--- a/src/template/mod.rs
+++ b/src/template/mod.rs
@@ -30,12 +30,12 @@
 //! let output = template.render(&context)?;
 //! ```
 
-mod ast;
+pub mod ast;
 mod error;
 mod eval;
-mod lexer;
-mod parser;
+pub mod lexer;
+pub mod parser;
 mod render;
 
 pub use eval::{Context, Value};
-pub use render::{Engine, InMemoryLoader};
+pub use render::{Engine, InMemoryLoader, Template};


### PR DESCRIPTION
## Summary

- Add divan benchmarks for link_checker (extract links, check internal links with 10/100/1000 page sites)
- Add divan benchmarks for ansi_to_html (plain text, ANSI codes, RGB colors, compiler errors, throughput)  
- Add divan benchmarks for template engine (lexer, parser, full render at various complexity levels)
- Export modules in lib.rs for benchmark access

## Test plan

- [x] `cargo bench --bench html_diff` runs successfully
- [x] `cargo bench --bench link_checker` runs successfully
- [x] `cargo bench --bench ansi_to_html` runs successfully
- [x] `cargo bench --bench template` runs successfully
- [x] All benchmarks produce sensible timing results

Closes #40