### PR TITLE
feat: modularize minify, svgo, and sass into plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1613,7 +1613,6 @@ dependencies = [
  "fontcull",
  "futures",
  "futures-util",
- "grass",
  "html5ever 0.36.1",
  "if-addrs",
  "ignore",
@@ -1624,7 +1623,6 @@ dependencies = [
  "markup5ever_rcdom",
  "maud",
  "miette",
- "minify-html",
  "nom 7.1.3",
  "notify",
  "open",
@@ -1644,7 +1642,6 @@ dependencies = [
  "salsa",
  "serde",
  "serde_yaml 0.9.34+deprecated",
- "svag",
  "syntect",
  "test-log",
  "thiserror 2.0.17",
@@ -1672,6 +1669,36 @@ dependencies = [
  "jpegxl-rs",
  "linkme",
  "plugcard",
+]
+
+[[package]]
+name = "dodeca-minify"
+version = "0.1.0"
+dependencies = [
+ "facet",
+ "linkme",
+ "minify-html",
+ "plugcard",
+]
+
+[[package]]
+name = "dodeca-sass"
+version = "0.1.0"
+dependencies = [
+ "facet",
+ "grass",
+ "linkme",
+ "plugcard",
+]
+
+[[package]]
+name = "dodeca-svgo"
+version = "0.1.0"
+dependencies = [
+ "facet",
+ "linkme",
+ "plugcard",
+ "svag",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "crates/livereload-client", "crates/plugcard", "crates/plugcard-macros", "crates/dodeca-baseline", "crates/dodeca-webp", "crates/dodeca-jxl", "xtask"]
+members = [".", "crates/livereload-client", "crates/plugcard", "crates/plugcard-macros", "crates/dodeca-baseline", "crates/dodeca-webp", "crates/dodeca-jxl", "crates/dodeca-minify", "crates/dodeca-svgo", "crates/dodeca-sass", "xtask"]
 
 [package]
 name = "dodeca"
@@ -64,9 +64,6 @@ rayon = "1"
 # CLI (using facet-args instead of clap)
 facet-args = { git = "https://github.com/facet-rs/facet" }
 
-# Sass
-grass = "0.13"
-
 # Error handling & diagnostics
 color-eyre = "0.6"
 miette = { version = "7", features = ["fancy"] }
@@ -124,18 +121,12 @@ image = { version = "0.25", default-features = false, features = ["jpeg", "png",
 rgb = "0.8"
 thumbhash = "0.1"  # Compact image placeholders (~28 bytes)
 
-# Plugin system for image encoding/decoding (WebP, JXL via plugins)
+# Plugin system for image encoding/decoding, minification, etc.
 plugcard = { path = "crates/plugcard" }
-
-# HTML minification
-minify-html = "0.18"
 
 # HTML parsing (for DOM diffing)
 html5ever = "0.36"
 markup5ever_rcdom = "0.36"
-
-# SVG optimization
-svag = { git = "https://github.com/bearcove/svag" }
 
 # Minimal-versions workarounds: these transitive deps have ancient minimum
 # version specs that don't build on modern Rust

--- a/crates/dodeca-minify/Cargo.toml
+++ b/crates/dodeca-minify/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "dodeca-minify"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.85"
+description = "HTML minification plugin for dodeca"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+plugcard = { path = "../plugcard" }
+facet = { git = "https://github.com/facet-rs/facet" }
+linkme = "0.3"
+
+# HTML minification
+minify-html = "0.18"

--- a/crates/dodeca-minify/src/lib.rs
+++ b/crates/dodeca-minify/src/lib.rs
@@ -1,0 +1,67 @@
+//! HTML minification plugin for dodeca
+
+use plugcard::{plugcard, PlugResult};
+
+plugcard::export_plugin!();
+
+/// Minify HTML content
+///
+/// Returns minified HTML, or an error if minification fails.
+#[plugcard]
+pub fn minify_html(html: String) -> PlugResult<String> {
+    let cfg = minify_html::Cfg {
+        minify_css: true,
+        minify_js: true,
+        // Preserve template syntax for compatibility
+        preserve_brace_template_syntax: true,
+        ..minify_html::Cfg::default()
+    };
+
+    let result = minify_html::minify(html.as_bytes(), &cfg);
+    match String::from_utf8(result) {
+        Ok(minified) => PlugResult::Ok(minified),
+        Err(_) => PlugResult::Err("minification produced invalid UTF-8".to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_minify_html() {
+        let input = r#"<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test</title>
+  </head>
+  <body>
+    <p>Hello World</p>
+  </body>
+</html>"#;
+
+        let result = minify_html(input.to_string());
+        let PlugResult::Ok(output) = result else {
+            panic!("Expected Ok, got Err");
+        };
+        assert!(output.len() < input.len());
+        assert!(output.contains("<p>Hello World"));
+        assert!(output.contains("<title>Test"));
+    }
+
+    #[test]
+    fn test_minify_with_css() {
+        let input = r#"<style>
+  body {
+    color: red;
+  }
+</style>"#;
+
+        let result = minify_html(input.to_string());
+        let PlugResult::Ok(output) = result else {
+            panic!("Expected Ok, got Err");
+        };
+        assert!(output.len() < input.len());
+        assert!(output.contains("color:red") || output.contains("color: red"));
+    }
+}

--- a/crates/dodeca-sass/Cargo.toml
+++ b/crates/dodeca-sass/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "dodeca-sass"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.85"
+description = "SASS/SCSS compilation plugin for dodeca"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+plugcard = { path = "../plugcard" }
+facet = { git = "https://github.com/facet-rs/facet" }
+linkme = "0.3"
+
+# SASS/SCSS compilation
+grass = "0.13"

--- a/crates/dodeca-sass/src/lib.rs
+++ b/crates/dodeca-sass/src/lib.rs
@@ -1,0 +1,137 @@
+//! SASS/SCSS compilation plugin for dodeca
+//!
+//! Compiles SASS/SCSS to CSS using grass.
+
+use facet::Facet;
+use plugcard::{plugcard, PlugResult};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+plugcard::export_plugin!();
+
+/// Input for SASS compilation - a map of filename -> content pairs
+#[derive(Facet)]
+pub struct SassInput {
+    pub files: HashMap<String, String>,
+}
+
+/// Compile SASS/SCSS to CSS
+///
+/// Takes a map of filename -> content pairs, with "main.scss" as the entry point.
+/// Returns compiled CSS, or an error if compilation fails.
+#[plugcard]
+pub fn compile_sass(input: SassInput) -> PlugResult<String> {
+    let files = input.files;
+
+    // Find main.scss
+    let main_content = match files.get("main.scss") {
+        Some(content) => content,
+        None => return PlugResult::Err("main.scss not found in files".to_string()),
+    };
+
+    // Create an in-memory filesystem for grass
+    let fs = InMemorySassFs::new(&files);
+
+    // Compile with grass using in-memory fs
+    let options = grass::Options::default().fs(&fs);
+
+    match grass::from_string(main_content.clone(), &options) {
+        Ok(css) => PlugResult::Ok(css),
+        Err(e) => PlugResult::Err(format!("SASS compilation failed: {}", e)),
+    }
+}
+
+/// In-memory filesystem for grass SASS compiler
+#[derive(Debug)]
+struct InMemorySassFs {
+    files: HashMap<PathBuf, Vec<u8>>,
+}
+
+impl InMemorySassFs {
+    fn new(sass_map: &HashMap<String, String>) -> Self {
+        let files = sass_map
+            .iter()
+            .map(|(path, content)| (PathBuf::from(path), content.as_bytes().to_vec()))
+            .collect();
+        Self { files }
+    }
+}
+
+impl grass::Fs for InMemorySassFs {
+    fn is_dir(&self, path: &Path) -> bool {
+        // Check if any file is under this directory
+        self.files.keys().any(|f| f.starts_with(path))
+    }
+
+    fn is_file(&self, path: &Path) -> bool {
+        self.files.contains_key(path)
+    }
+
+    fn read(&self, path: &Path) -> std::io::Result<Vec<u8>> {
+        self.files.get(path).cloned().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("File not found: {path:?}"),
+            )
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compile_simple_sass() {
+        let mut files = HashMap::new();
+        files.insert(
+            "main.scss".to_string(),
+            r#"
+            $primary: #ff0000;
+            body {
+                color: $primary;
+            }
+            "#
+            .to_string(),
+        );
+
+        let result = compile_sass(SassInput { files });
+        let PlugResult::Ok(css) = result else {
+            panic!("Expected Ok, got Err");
+        };
+        assert!(css.contains("color:") || css.contains("color :"));
+        assert!(css.contains("#ff0000") || css.contains("red"));
+    }
+
+    #[test]
+    fn test_compile_with_import() {
+        let mut files = HashMap::new();
+        files.insert(
+            "_variables.scss".to_string(),
+            "$primary: blue;".to_string(),
+        );
+        files.insert(
+            "main.scss".to_string(),
+            r#"
+            @use "variables";
+            body {
+                color: variables.$primary;
+            }
+            "#
+            .to_string(),
+        );
+
+        let result = compile_sass(SassInput { files });
+        let PlugResult::Ok(css) = result else {
+            panic!("Expected Ok, got {:?}", result);
+        };
+        assert!(css.contains("color:") || css.contains("color :"));
+    }
+
+    #[test]
+    fn test_missing_main() {
+        let files = HashMap::new();
+        let result = compile_sass(SassInput { files });
+        assert!(matches!(result, PlugResult::Err(_)));
+    }
+}

--- a/crates/dodeca-svgo/Cargo.toml
+++ b/crates/dodeca-svgo/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "dodeca-svgo"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.85"
+description = "SVG optimization plugin for dodeca"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+plugcard = { path = "../plugcard" }
+facet = { git = "https://github.com/facet-rs/facet" }
+linkme = "0.3"
+
+# SVG optimization
+svag = { git = "https://github.com/bearcove/svag" }

--- a/crates/dodeca-svgo/src/lib.rs
+++ b/crates/dodeca-svgo/src/lib.rs
@@ -1,0 +1,60 @@
+//! SVG optimization plugin for dodeca
+//!
+//! Removes unnecessary metadata, collapses groups, optimizes paths, etc.
+//! Preserves case sensitivity of SVG attributes.
+
+use plugcard::{plugcard, PlugResult};
+
+plugcard::export_plugin!();
+
+/// Optimize SVG content
+///
+/// Returns optimized SVG, or an error if optimization fails.
+#[plugcard]
+pub fn optimize_svg(svg: String) -> PlugResult<String> {
+    match svag::minify(&svg) {
+        Ok(optimized) => PlugResult::Ok(optimized),
+        Err(e) => PlugResult::Err(format!("SVG optimization failed: {}", e)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_optimize_svg() {
+        let input = r##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+            <!-- A red circle -->
+            <circle cx="50" cy="50" r="40" fill="#ff0000"/>
+        </svg>"##;
+
+        let result = optimize_svg(input.to_string());
+        let PlugResult::Ok(output) = result else {
+            panic!("Expected Ok, got Err");
+        };
+        // Should be smaller (removes comments, optimizes colors)
+        assert!(output.len() < input.len(), "expected smaller output");
+        // Should preserve viewBox (case-sensitive)
+        assert!(output.contains("viewBox"), "viewBox should be preserved");
+        // Should still have the circle
+        assert!(output.contains("circle"), "circle element should be preserved");
+    }
+
+    #[test]
+    fn test_optimize_svg_with_groups() {
+        let input = r#"<svg xmlns="http://www.w3.org/2000/svg">
+            <g>
+                <g>
+                    <rect x="0" y="0" width="10" height="10"/>
+                </g>
+            </g>
+        </svg>"#;
+
+        let result = optimize_svg(input.to_string());
+        let PlugResult::Ok(output) = result else {
+            panic!("Expected Ok, got Err");
+        };
+        assert!(output.contains("rect"), "rect element should be preserved");
+    }
+}

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -1,34 +1,25 @@
 //! Minification utilities
 //!
-//! Provides HTML minification via minify-html.
+//! Provides HTML and SVG minification via plugins.
 
-use minify_html::{Cfg, minify};
-
-/// Get a minification config optimized for production HTML
-fn html_cfg() -> Cfg {
-    Cfg {
-        minify_css: true,
-        minify_js: true,
-        // Preserve template syntax for compatibility
-        preserve_brace_template_syntax: true,
-        ..Cfg::default()
-    }
-}
+use crate::plugins::{minify_html_plugin, optimize_svg_plugin};
 
 /// Minify HTML content
 ///
 /// Returns minified HTML, or original content if minification fails
 pub fn minify_html(html: &str) -> String {
-    let result = minify(html.as_bytes(), &html_cfg());
-    String::from_utf8(result).unwrap_or_else(|_| html.to_string())
+    minify_html_plugin(html).unwrap_or_else(|e| {
+        tracing::warn!("HTML minification failed: {}", e);
+        html.to_string()
+    })
 }
 
-/// Optimize SVG content using svag
+/// Optimize SVG content
 ///
 /// Removes unnecessary metadata, collapses groups, optimizes paths, etc.
-/// Preserves case sensitivity of SVG attributes (unlike minify-html).
+/// Preserves case sensitivity of SVG attributes.
 pub fn optimize_svg(svg_content: &str) -> Option<String> {
-    svag::minify(svg_content).ok()
+    optimize_svg_plugin(svg_content).ok()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Create `dodeca-minify` plugin for HTML minification (was using `minify-html` directly)
- Create `dodeca-svgo` plugin for SVG optimization (was using `svag` directly)
- Create `dodeca-sass` plugin for SASS/SCSS compilation (was using `grass` directly)
- Update main crate to load and use these plugins at runtime
- Add platform-specific library extension detection (`.dylib` on macOS, `.so` on Linux, `.dll` on Windows)

All three plugins are required - the main crate will panic if they're not found.

## Test plan

- [x] `cargo test -p dodeca-minify` passes
- [x] `cargo test -p dodeca-svgo` passes  
- [x] `cargo test -p dodeca-sass` passes
- [x] `cargo test --bin ddc svg::` passes (uses plugins at runtime)
- [x] All plugins build as dynamic libraries

Partial progress on #33