### PR TITLE
feat: modularize CSS and JS processing into plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,7 +1617,6 @@ dependencies = [
  "if-addrs",
  "ignore",
  "image",
- "lightningcss",
  "livereload-client",
  "lol_html 2.7.0",
  "markup5ever_rcdom",
@@ -1627,7 +1626,6 @@ dependencies = [
  "notify",
  "open",
  "owo-colors",
- "oxc",
  "pagefind",
  "phf 0.11.3",
  "plugcard",
@@ -1642,7 +1640,6 @@ dependencies = [
  "salsa",
  "serde",
  "serde_yaml 0.9.34+deprecated",
- "syntect",
  "test-log",
  "thiserror 2.0.17",
  "thumbhash",
@@ -1659,6 +1656,26 @@ dependencies = [
  "linkme",
  "plugcard",
  "postcard-schema",
+]
+
+[[package]]
+name = "dodeca-css"
+version = "0.1.0"
+dependencies = [
+ "facet",
+ "lightningcss",
+ "linkme",
+ "plugcard",
+]
+
+[[package]]
+name = "dodeca-js"
+version = "0.1.0"
+dependencies = [
+ "facet",
+ "linkme",
+ "oxc",
+ "plugcard",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "crates/livereload-client", "crates/plugcard", "crates/plugcard-macros", "crates/dodeca-baseline", "crates/dodeca-webp", "crates/dodeca-jxl", "crates/dodeca-minify", "crates/dodeca-svgo", "crates/dodeca-sass", "xtask"]
+members = [".", "crates/livereload-client", "crates/plugcard", "crates/plugcard-macros", "crates/dodeca-baseline", "crates/dodeca-webp", "crates/dodeca-jxl", "crates/dodeca-minify", "crates/dodeca-svgo", "crates/dodeca-sass", "crates/dodeca-css", "crates/dodeca-js", "xtask"]
 
 [package]
 name = "dodeca"
@@ -36,9 +36,8 @@ facet-value = { git = "https://github.com/facet-rs/facet" }
 # YAML parsing (for data files - facet-yaml doesn't support dynamic values)
 serde_yaml = "0.9"
 
-# Markdown & syntax highlighting
+# Markdown parsing
 pulldown-cmark = "0.13"
-syntect = "5"
 
 # HTML generation
 maud = "0.27"
@@ -108,10 +107,8 @@ aliri_braid = "0.4"  # Strongly-typed string wrappers
 regex = "1"  # For HTML heading extraction
 url = "2"  # URL parsing for domain extraction
 
-# URL rewriting (precise, parser-based)
+# URL rewriting (HTML only - CSS/JS via plugins)
 lol_html = "2.7"        # Streaming HTML rewriter
-lightningcss = { version = "1.0.0-alpha.68", features = ["visitor"] }  # CSS parser/transformer
-oxc = { version = "0.100", features = ["full"] }  # JS parser/minifier
 
 # Font subsetting (static analysis + klippa backend)
 fontcull = { git = "https://github.com/bearcove/fontcull", default-features = false, features = ["klippa", "static-analysis"] }

--- a/crates/dodeca-css/Cargo.toml
+++ b/crates/dodeca-css/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "dodeca-css"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.85"
+description = "CSS URL rewriting and minification plugin for dodeca"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+plugcard = { path = "../plugcard" }
+facet = { git = "https://github.com/facet-rs/facet" }
+linkme = "0.3"
+
+# CSS parsing and transformation
+lightningcss = { version = "1.0.0-alpha.68", features = ["visitor"] }

--- a/crates/dodeca-css/src/lib.rs
+++ b/crates/dodeca-css/src/lib.rs
@@ -1,0 +1,143 @@
+//! CSS URL rewriting and minification plugin for dodeca
+//!
+//! Uses lightningcss to parse CSS, rewrite url() values, and minify output.
+
+use facet::Facet;
+use lightningcss::stylesheet::{ParserOptions, PrinterOptions, StyleSheet};
+use lightningcss::visitor::Visit;
+use plugcard::{plugcard, PlugResult};
+use std::collections::HashMap;
+
+plugcard::export_plugin!();
+
+/// Input for CSS URL rewriting
+#[derive(Facet)]
+pub struct CssRewriteInput {
+    /// The CSS source code
+    pub css: String,
+    /// Map of old URLs to new URLs
+    pub path_map: HashMap<String, String>,
+}
+
+/// Rewrite URLs in CSS and minify
+///
+/// Parses CSS, rewrites url() values according to path_map, and returns minified CSS.
+#[plugcard]
+pub fn rewrite_urls_in_css(input: CssRewriteInput) -> PlugResult<String> {
+    // Parse the CSS
+    let mut stylesheet = match StyleSheet::parse(&input.css, ParserOptions::default()) {
+        Ok(s) => s,
+        Err(e) => {
+            return PlugResult::Err(format!("Failed to parse CSS: {:?}", e));
+        }
+    };
+
+    // Visit and rewrite URLs
+    let mut visitor = UrlRewriter {
+        path_map: &input.path_map,
+    };
+    if let Err(e) = stylesheet.visit(&mut visitor) {
+        return PlugResult::Err(format!("Failed to visit CSS: {:?}", e));
+    }
+
+    // Serialize back to string with minification enabled
+    let printer_options = PrinterOptions {
+        minify: true,
+        ..Default::default()
+    };
+    match stylesheet.to_css(printer_options) {
+        Ok(result) => PlugResult::Ok(result.code),
+        Err(e) => PlugResult::Err(format!("Failed to serialize CSS: {:?}", e)),
+    }
+}
+
+/// Visitor that rewrites URLs in CSS
+struct UrlRewriter<'a> {
+    path_map: &'a HashMap<String, String>,
+}
+
+impl<'i, 'a> lightningcss::visitor::Visitor<'i> for UrlRewriter<'a> {
+    type Error = std::convert::Infallible;
+
+    fn visit_types(&self) -> lightningcss::visitor::VisitTypes {
+        lightningcss::visit_types!(URLS)
+    }
+
+    fn visit_url(
+        &mut self,
+        url: &mut lightningcss::values::url::Url<'i>,
+    ) -> Result<(), Self::Error> {
+        let url_str = url.url.as_ref();
+        if let Some(new_url) = self.path_map.get(url_str) {
+            url.url = new_url.clone().into();
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rewrite_css_urls() {
+        let css = r#"
+            @font-face {
+                font-family: "Inter";
+                src: url("/fonts/Inter.woff2") format("woff2");
+            }
+            body {
+                background: url("/images/bg.png");
+            }
+        "#;
+
+        let mut path_map = HashMap::new();
+        path_map.insert(
+            "/fonts/Inter.woff2".to_string(),
+            "/fonts/Inter.abc123.woff2".to_string(),
+        );
+        path_map.insert(
+            "/images/bg.png".to_string(),
+            "/images/bg.def456.png".to_string(),
+        );
+
+        let input = CssRewriteInput {
+            css: css.to_string(),
+            path_map,
+        };
+
+        let result = rewrite_urls_in_css(input);
+        let PlugResult::Ok(output) = result else {
+            panic!("Expected Ok, got Err");
+        };
+
+        assert!(output.contains("/fonts/Inter.abc123.woff2"));
+        assert!(output.contains("/images/bg.def456.png"));
+        assert!(!output.contains("\"/fonts/Inter.woff2\""));
+        assert!(!output.contains("\"/images/bg.png\""));
+    }
+
+    #[test]
+    fn test_minification() {
+        let css = r#"
+            body {
+                color: red;
+                background: blue;
+            }
+        "#;
+
+        let input = CssRewriteInput {
+            css: css.to_string(),
+            path_map: HashMap::new(),
+        };
+
+        let result = rewrite_urls_in_css(input);
+        let PlugResult::Ok(output) = result else {
+            panic!("Expected Ok, got Err");
+        };
+
+        // Should be minified (no unnecessary whitespace)
+        assert!(output.len() < css.len());
+        assert!(output.contains("color:red") || output.contains("color: red"));
+    }
+}

--- a/crates/dodeca-js/Cargo.toml
+++ b/crates/dodeca-js/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "dodeca-js"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.85"
+description = "JavaScript string literal rewriting plugin for dodeca"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+plugcard = { path = "../plugcard" }
+facet = { git = "https://github.com/facet-rs/facet" }
+linkme = "0.3"
+
+# JavaScript parsing
+oxc = { version = "0.100", features = ["full"] }

--- a/crates/dodeca-js/src/lib.rs
+++ b/crates/dodeca-js/src/lib.rs
@@ -1,0 +1,204 @@
+//! JavaScript string literal rewriting plugin for dodeca
+//!
+//! Uses OXC parser to find and rewrite string literals containing asset paths.
+
+use facet::Facet;
+use oxc::allocator::Allocator;
+use oxc::ast::ast::{StringLiteral, TemplateLiteral};
+use oxc::ast_visit::Visit;
+use oxc::parser::Parser;
+use oxc::span::SourceType;
+use plugcard::{plugcard, PlugResult};
+use std::collections::HashMap;
+
+plugcard::export_plugin!();
+
+/// Input for JS string literal rewriting
+#[derive(Facet)]
+pub struct JsRewriteInput {
+    /// The JavaScript source code
+    pub js: String,
+    /// Map of old paths to new paths
+    pub path_map: HashMap<String, String>,
+}
+
+/// Rewrite string literals in JavaScript that contain asset paths
+///
+/// Parses JavaScript, finds string literals matching paths in path_map,
+/// and replaces them with the new paths.
+#[plugcard]
+pub fn rewrite_string_literals_in_js(input: JsRewriteInput) -> PlugResult<String> {
+    let js = &input.js;
+    let path_map = &input.path_map;
+
+    // Parse the JavaScript
+    let allocator = Allocator::default();
+    let source_type = SourceType::mjs(); // Treat as ES module
+    let parser_result = Parser::new(&allocator, js, source_type).parse();
+
+    if parser_result.panicked || !parser_result.errors.is_empty() {
+        // If parsing fails, return unchanged (could be a snippet or invalid JS)
+        return PlugResult::Ok(js.to_string());
+    }
+
+    // Collect string literal positions and their replacement values
+    let mut replacements: Vec<(u32, u32, String)> = Vec::new(); // (start, end, new_value)
+    let mut collector = StringCollector {
+        source: js,
+        path_map,
+        replacements: &mut replacements,
+    };
+    collector.visit_program(&parser_result.program);
+
+    // Apply replacements in reverse order (so offsets stay valid)
+    if replacements.is_empty() {
+        return PlugResult::Ok(js.to_string());
+    }
+
+    replacements.sort_by(|a, b| b.0.cmp(&a.0)); // Sort by start position, descending
+
+    let mut result = js.to_string();
+    for (start, end, new_value) in replacements {
+        result.replace_range(start as usize..end as usize, &new_value);
+    }
+
+    PlugResult::Ok(result)
+}
+
+/// Visitor that collects string literals for replacement
+struct StringCollector<'a> {
+    source: &'a str,
+    path_map: &'a HashMap<String, String>,
+    replacements: &'a mut Vec<(u32, u32, String)>,
+}
+
+impl<'a> Visit<'_> for StringCollector<'a> {
+    fn visit_string_literal(&mut self, lit: &StringLiteral<'_>) {
+        let value = lit.value.as_str();
+        let mut new_value = value.to_string();
+        let mut changed = false;
+
+        for (old_path, new_path) in self.path_map.iter() {
+            if new_value.contains(old_path.as_str()) {
+                new_value = new_value.replace(old_path, new_path);
+                changed = true;
+            }
+        }
+
+        if changed {
+            // Get the original source including quotes
+            let start = lit.span.start;
+            let end = lit.span.end;
+            let original = &self.source[start as usize..end as usize];
+            let quote = original.chars().next().unwrap_or('"');
+            self.replacements
+                .push((start, end, format!("{quote}{new_value}{quote}")));
+        }
+    }
+
+    fn visit_template_literal(&mut self, lit: &TemplateLiteral<'_>) {
+        // Handle template literal quasi strings
+        for quasi in &lit.quasis {
+            let value = quasi.value.raw.as_str();
+            let mut new_value = value.to_string();
+            let mut changed = false;
+
+            for (old_path, new_path) in self.path_map.iter() {
+                if new_value.contains(old_path.as_str()) {
+                    new_value = new_value.replace(old_path, new_path);
+                    changed = true;
+                }
+            }
+
+            if changed {
+                // For template literals, we only replace the quasi part
+                let start = quasi.span.start;
+                let end = quasi.span.end;
+                self.replacements.push((start, end, new_value));
+            }
+        }
+
+        // Continue visiting expressions inside template literal
+        for expr in &lit.expressions {
+            self.visit_expression(expr);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rewrite_string_literals() {
+        let js = r#"
+            const a = "/images/logo.png";
+            const b = '/images/icon.svg';
+            const c = `/images/hero.jpg`;
+            const d = "/not/in/map.png";
+        "#;
+
+        let mut path_map = HashMap::new();
+        path_map.insert(
+            "/images/logo.png".to_string(),
+            "/images/logo.abc.png".to_string(),
+        );
+        path_map.insert(
+            "/images/icon.svg".to_string(),
+            "/images/icon.def.svg".to_string(),
+        );
+        path_map.insert(
+            "/images/hero.jpg".to_string(),
+            "/images/hero.ghi.jpg".to_string(),
+        );
+
+        let input = JsRewriteInput {
+            js: js.to_string(),
+            path_map,
+        };
+
+        let result = rewrite_string_literals_in_js(input);
+        let PlugResult::Ok(output) = result else {
+            panic!("Expected Ok, got Err");
+        };
+
+        assert!(output.contains("\"/images/logo.abc.png\""));
+        assert!(output.contains("'/images/icon.def.svg'"));
+        assert!(output.contains("`/images/hero.ghi.jpg`"));
+        assert!(output.contains("\"/not/in/map.png\"")); // unchanged
+    }
+
+    #[test]
+    fn test_invalid_js_returns_unchanged() {
+        let js = "this is not { valid javascript";
+
+        let input = JsRewriteInput {
+            js: js.to_string(),
+            path_map: HashMap::new(),
+        };
+
+        let result = rewrite_string_literals_in_js(input);
+        let PlugResult::Ok(output) = result else {
+            panic!("Expected Ok, got Err");
+        };
+
+        assert_eq!(output, js);
+    }
+
+    #[test]
+    fn test_empty_path_map() {
+        let js = r#"const x = "/images/test.png";"#;
+
+        let input = JsRewriteInput {
+            js: js.to_string(),
+            path_map: HashMap::new(),
+        };
+
+        let result = rewrite_string_literals_in_js(input);
+        let PlugResult::Ok(output) = result else {
+            panic!("Expected Ok, got Err");
+        };
+
+        assert_eq!(output, js);
+    }
+}

--- a/src/link_checker.rs
+++ b/src/link_checker.rs
@@ -171,12 +171,6 @@ impl ExternalLinkOptions {
         self
     }
 
-    /// Set the minimum delay between requests to the same domain
-    pub fn rate_limit(mut self, delay: Duration) -> Self {
-        self.rate_limit = delay;
-        self
-    }
-
     /// Set the rate limit in milliseconds
     pub fn rate_limit_ms(mut self, ms: u64) -> Self {
         self.rate_limit = Duration::from_millis(ms);

--- a/src/template/mod.rs
+++ b/src/template/mod.rs
@@ -38,4 +38,4 @@ pub mod parser;
 mod render;
 
 pub use eval::{Context, Value};
-pub use render::{Engine, InMemoryLoader, Template};
+pub use render::{Engine, InMemoryLoader};

--- a/src/url_rewrite.rs
+++ b/src/url_rewrite.rs
@@ -1,73 +1,24 @@
 //! Precise URL rewriting using proper parsers
 //!
-//! - CSS: Uses lightningcss visitor API to find and rewrite `url()` values
+//! - CSS: Uses lightningcss visitor API to find and rewrite `url()` values (via plugin)
 //! - HTML: Uses lol_html to rewrite attributes and inline style/script content
-//! - JS: Uses OXC parser to find string literals and rewrite asset paths
+//! - JS: Uses OXC parser to find string literals and rewrite asset paths (via plugin)
 
 use std::collections::{HashMap, HashSet};
 
-// OXC imports for JS string literal rewriting
-use oxc::ast_visit::Visit;
+use crate::plugins::{rewrite_string_literals_in_js_plugin, rewrite_urls_in_css_plugin};
 
-/// Rewrite URLs in CSS using lightningcss parser
+/// Rewrite URLs in CSS using lightningcss parser (via plugin)
 ///
 /// Only rewrites actual `url()` values in CSS, not text that happens to look like URLs.
 /// Also minifies the CSS output.
 pub fn rewrite_urls_in_css(css: &str, path_map: &HashMap<String, String>) -> String {
-    use lightningcss::stylesheet::{ParserOptions, PrinterOptions, StyleSheet};
-    use lightningcss::visitor::Visit;
-
-    // Parse the CSS
-    let mut stylesheet = match StyleSheet::parse(css, ParserOptions::default()) {
-        Ok(s) => s,
+    match rewrite_urls_in_css_plugin(css, path_map) {
+        Ok(result) => result,
         Err(e) => {
-            tracing::warn!("Failed to parse CSS for URL rewriting: {:?}", e);
-            return css.to_string();
-        }
-    };
-
-    // Visit and rewrite URLs
-    let mut visitor = UrlRewriter { path_map };
-    if let Err(e) = stylesheet.visit(&mut visitor) {
-        tracing::warn!("Failed to visit CSS: {:?}", e);
-        return css.to_string();
-    }
-
-    // Serialize back to string with minification enabled
-    let printer_options = PrinterOptions {
-        minify: true,
-        ..Default::default()
-    };
-    match stylesheet.to_css(printer_options) {
-        Ok(result) => result.code,
-        Err(e) => {
-            tracing::warn!("Failed to serialize CSS: {:?}", e);
+            tracing::warn!("CSS rewriting failed: {}", e);
             css.to_string()
         }
-    }
-}
-
-/// Visitor that rewrites URLs in CSS
-struct UrlRewriter<'a> {
-    path_map: &'a HashMap<String, String>,
-}
-
-impl<'i, 'a> lightningcss::visitor::Visitor<'i> for UrlRewriter<'a> {
-    type Error = std::convert::Infallible;
-
-    fn visit_types(&self) -> lightningcss::visitor::VisitTypes {
-        lightningcss::visit_types!(URLS)
-    }
-
-    fn visit_url(
-        &mut self,
-        url: &mut lightningcss::values::url::Url<'i>,
-    ) -> Result<(), Self::Error> {
-        let url_str = url.url.as_ref();
-        if let Some(new_url) = self.path_map.get(url_str) {
-            url.url = new_url.clone().into();
-        }
-        Ok(())
     }
 }
 
@@ -267,105 +218,14 @@ fn rewrite_script_tags(html: &str, path_map: &HashMap<String, String>) -> String
 
 /// Rewrite string literals in JavaScript that contain asset paths
 ///
-/// Uses OXC parser to properly parse JavaScript and find string literals,
+/// Uses OXC parser (via plugin) to properly parse JavaScript and find string literals,
 /// then replaces paths with cache-busted versions.
 fn rewrite_string_literals_in_js(js: &str, path_map: &HashMap<String, String>) -> String {
-    use oxc::allocator::Allocator;
-    use oxc::ast_visit::Visit;
-    use oxc::parser::Parser;
-    use oxc::span::SourceType;
-
-    // Parse the JavaScript
-    let allocator = Allocator::default();
-    let source_type = SourceType::mjs(); // Treat as ES module
-    let parser_result = Parser::new(&allocator, js, source_type).parse();
-
-    if parser_result.panicked || !parser_result.errors.is_empty() {
-        // If parsing fails, return unchanged (could be a snippet or invalid JS)
-        tracing::debug!("JS parsing failed, returning unchanged");
-        return js.to_string();
-    }
-
-    // Collect string literal positions and their replacement values
-    let mut replacements: Vec<(u32, u32, String)> = Vec::new(); // (start, end, new_value)
-    let mut collector = StringCollector {
-        source: js,
-        path_map,
-        replacements: &mut replacements,
-    };
-    collector.visit_program(&parser_result.program);
-
-    // Apply replacements in reverse order (so offsets stay valid)
-    if replacements.is_empty() {
-        return js.to_string();
-    }
-
-    replacements.sort_by(|a, b| b.0.cmp(&a.0)); // Sort by start position, descending
-
-    let mut result = js.to_string();
-    for (start, end, new_value) in replacements {
-        result.replace_range(start as usize..end as usize, &new_value);
-    }
-
-    result
-}
-
-/// Visitor that collects string literals for replacement
-struct StringCollector<'a> {
-    source: &'a str,
-    path_map: &'a HashMap<String, String>,
-    replacements: &'a mut Vec<(u32, u32, String)>,
-}
-
-impl<'a> Visit<'_> for StringCollector<'a> {
-    fn visit_string_literal(&mut self, lit: &oxc::ast::ast::StringLiteral<'_>) {
-        let value = lit.value.as_str();
-        let mut new_value = value.to_string();
-        let mut changed = false;
-
-        for (old_path, new_path) in self.path_map.iter() {
-            if new_value.contains(old_path.as_str()) {
-                new_value = new_value.replace(old_path, new_path);
-                changed = true;
-            }
-        }
-
-        if changed {
-            // Get the original source including quotes
-            let start = lit.span.start;
-            let end = lit.span.end;
-            let original = &self.source[start as usize..end as usize];
-            let quote = original.chars().next().unwrap_or('"');
-            self.replacements
-                .push((start, end, format!("{quote}{new_value}{quote}")));
-        }
-    }
-
-    fn visit_template_literal(&mut self, lit: &oxc::ast::ast::TemplateLiteral<'_>) {
-        // Handle template literal quasi strings
-        for quasi in &lit.quasis {
-            let value = quasi.value.raw.as_str();
-            let mut new_value = value.to_string();
-            let mut changed = false;
-
-            for (old_path, new_path) in self.path_map.iter() {
-                if new_value.contains(old_path.as_str()) {
-                    new_value = new_value.replace(old_path, new_path);
-                    changed = true;
-                }
-            }
-
-            if changed {
-                // For template literals, we only replace the quasi part
-                let start = quasi.span.start;
-                let end = quasi.span.end;
-                self.replacements.push((start, end, new_value));
-            }
-        }
-
-        // Continue visiting expressions inside template literal
-        for expr in &lit.expressions {
-            self.visit_expression(expr);
+    match rewrite_string_literals_in_js_plugin(js, path_map) {
+        Ok(result) => result,
+        Err(e) => {
+            tracing::warn!("JS rewriting failed: {}", e);
+            js.to_string()
         }
     }
 }


### PR DESCRIPTION
## Summary
- Extract lightningcss and OXC into `dodeca-css` and `dodeca-js` plugins
- Continue plugcard modularization effort from #33
- Remove direct OXC/lightningcss dependencies from main crate

## Changes
- **dodeca-css**: CSS URL rewriting and minification using lightningcss
- **dodeca-js**: JS string literal rewriting using OXC parser
- Updated `url_rewrite.rs` to use plugins instead of inline code
- Updated `plugins.rs` with new plugin loaders

## Test plan
- [x] Plugin unit tests pass (`cargo test -p dodeca-css -p dodeca-js`)
- [x] Main crate url_rewrite tests pass (`cargo test url_rewrite`)
- [x] Full build succeeds