### PR TITLE
bench: add minijinja comparison benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1590,7 +1590,7 @@ dependencies = [
 
 [[package]]
 name = "dodeca"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "aliri_braid",
  "axum",
@@ -1622,6 +1622,7 @@ dependencies = [
  "markup5ever_rcdom",
  "maud",
  "miette",
+ "minijinja",
  "nom 7.1.3",
  "notify",
  "open",
@@ -3879,6 +3880,15 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "minijinja"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0adbe6e92a6ce0fd6c4aac593fdfd3e3950b0f61b1a63aa9731eb6fd85776fa3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,7 @@ nom = "7"     # 7+ drops lexical-core 0.7 (broken usize/u32 ops)
 [dev-dependencies]
 reqwest = { version = "0.12", features = ["blocking"] }
 divan = "0.1"
+minijinja = "2"  # For template engine benchmarks
 test-log = { version = "0.2", features = ["trace"] }
 regex = "1"  # For test assertions
 tempfile = "3"  # For isolated test fixtures


### PR DESCRIPTION
## Summary
- Add minijinja as a dev dependency for benchmarking comparison
- Extend template benchmarks with equivalent minijinja tests for:
  - Simple text rendering
  - Variable interpolation
  - Loop rendering
  - Complex templates
  - Loop scaling (10, 100, 1000 iterations)

## Benchmark Results

| Benchmark | dodeca | minijinja | ratio |
|-----------|--------|-----------|-------|
| simple | 604 ns | 265 ns | 2.3x |
| with_variables | 2.58 µs | 427 ns | 6x |
| with_loops | 11.79 µs | 2.58 µs | 4.6x |
| complex | 26.24 µs | 2.87 µs | 9.1x |
| loop_scaling 1000 | 550.7 µs | 93.27 µs | 5.9x |

minijinja is 4-9x faster, which is expected for a mature optimized engine. Key observations:
- dodeca re-parses templates on every render (no caching)
- Variable lookup overhead is noticeable
- Loop overhead is significant

This gives a baseline for future optimization work.

## Test plan
- [x] `cargo bench --bench template` runs successfully
- [x] Both dodeca and minijinja benchmarks produce reasonable results

Closes #37