### PR TITLE
fix: add rust-toolchain.toml for Rust 1.91

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.91"


### PR DESCRIPTION
## Summary

Fix release CI failure by adding `rust-toolchain.toml` that pins Rust 1.91.

## Problem

Release workflow failed with:
```
error: rustc 1.89.0 is not supported by the following packages:
  dodeca@0.2.0 requires rustc 1.91
```

cargo-dist was using the default Rust version (1.89) but dodeca uses `edition = "2024"` which requires Rust 1.91+.

## Solution

Add `rust-toolchain.toml`:
```toml
[toolchain]
channel = "1.91"
```

This ensures rustup installs 1.91 before building, which cargo-dist respects.

## Test plan

- [ ] Release workflow should now succeed