### PR TITLE
feat: lazy data loading with per-value Salsa tracking

### DIFF
--- a/crates/gingembre/src/lazy.rs
+++ b/crates/gingembre/src/lazy.rs
@@ -1,0 +1,684 @@
+//! Lazy value system for fine-grained dependency tracking.
+//!
+//! This module provides [`LazyValue`], a wrapper around [`facet_value::Value`]
+//! that supports lazy resolution. Field access on lazy values extends a path
+//! rather than immediately resolving, allowing dependency tracking systems
+//! (like Salsa) to track exactly which values are accessed.
+//!
+//! # How It Works
+//!
+//! ```text
+//! data.versions.dodeca.version
+//!      ↓
+//! LazyValue { path: [] }
+//!      ↓ .versions
+//! LazyValue { path: ["versions"] }  ← no resolution yet!
+//!      ↓ .dodeca
+//! LazyValue { path: ["versions", "dodeca"] }
+//!      ↓ .version
+//! LazyValue { path: ["versions", "dodeca", "version"] }
+//!      ↓ print/compare/etc
+//! resolver.resolve(path) → concrete value + dependency tracked
+//! ```
+
+use crate::error::{TemplateSource, TypeError, UnknownFieldError};
+use facet_value::DestructuredRef;
+use miette::Result;
+use std::sync::Arc;
+
+/// A path through a data tree.
+///
+/// Paths are sequences of string segments representing navigation through
+/// nested objects and arrays. For example, `["versions", "dodeca", "version"]`
+/// represents `data.versions.dodeca.version`.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
+pub struct DataPath(pub Vec<String>);
+
+impl DataPath {
+    /// Create an empty (root) path.
+    pub fn root() -> Self {
+        Self(Vec::new())
+    }
+
+    /// Create a new path by appending a segment.
+    pub fn push(&self, segment: impl Into<String>) -> Self {
+        let mut new_path = self.0.clone();
+        new_path.push(segment.into());
+        Self(new_path)
+    }
+
+    /// Get the path segments.
+    pub fn segments(&self) -> &[String] {
+        &self.0
+    }
+
+    /// Check if this is the root path.
+    pub fn is_root(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl std::fmt::Display for DataPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.0.is_empty() {
+            write!(f, "(root)")
+        } else {
+            write!(f, "{}", self.0.join("."))
+        }
+    }
+}
+
+/// Trait for resolving lazy data values by path.
+///
+/// Implementations should track dependencies - each unique path that is
+/// resolved becomes a separate dependency in the tracking system.
+///
+/// # Example
+///
+/// A Salsa-backed resolver would create a tracked query for each path,
+/// allowing fine-grained cache invalidation when specific values change.
+pub trait DataResolver: Send + Sync {
+    /// Resolve a value at the given path.
+    ///
+    /// Returns `None` if the path doesn't exist in the data tree.
+    fn resolve(&self, path: &DataPath) -> Option<facet_value::Value>;
+
+    /// Get all child keys at a path (for iteration).
+    ///
+    /// Returns `None` if the path doesn't exist or points to a non-container value.
+    /// For objects, returns the field names.
+    /// For arrays, returns string indices ("0", "1", etc.).
+    fn keys_at(&self, path: &DataPath) -> Option<Vec<String>>;
+
+    /// Get the number of children at a path.
+    ///
+    /// Returns `None` if the path doesn't exist or isn't a container.
+    fn len_at(&self, path: &DataPath) -> Option<usize> {
+        self.keys_at(path).map(|k| k.len())
+    }
+}
+
+/// A value that may be lazily resolved.
+///
+/// Field access on lazy values extends the path rather than immediately
+/// resolving. Resolution happens only when a concrete value is needed
+/// (printing, comparison, arithmetic, etc.).
+///
+/// This enables fine-grained dependency tracking: each unique path that
+/// is actually used becomes a separate tracked dependency.
+#[derive(Clone)]
+pub enum LazyValue {
+    /// A concrete, already-resolved value.
+    Concrete(facet_value::Value),
+
+    /// A lazy reference that will be resolved on demand.
+    Lazy {
+        /// The resolver that can fetch values by path.
+        resolver: Arc<dyn DataResolver>,
+        /// The path through the data tree.
+        path: DataPath,
+    },
+}
+
+impl std::fmt::Debug for LazyValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Concrete(v) => write!(f, "Concrete({:?})", v),
+            Self::Lazy { path, .. } => write!(f, "Lazy {{ path: {} }}", path),
+        }
+    }
+}
+
+impl LazyValue {
+    /// Create a concrete value (no lazy resolution).
+    pub fn concrete(value: facet_value::Value) -> Self {
+        Self::Concrete(value)
+    }
+
+    /// Create a lazy value with a resolver and path.
+    pub fn lazy(resolver: Arc<dyn DataResolver>, path: DataPath) -> Self {
+        Self::Lazy { resolver, path }
+    }
+
+    /// Create a lazy value at the root path.
+    pub fn lazy_root(resolver: Arc<dyn DataResolver>) -> Self {
+        Self::Lazy {
+            resolver,
+            path: DataPath::root(),
+        }
+    }
+
+    /// Check if this is a lazy (unresolved) value.
+    pub fn is_lazy(&self) -> bool {
+        matches!(self, Self::Lazy { .. })
+    }
+
+    /// Check if this is a concrete (resolved) value.
+    pub fn is_concrete(&self) -> bool {
+        matches!(self, Self::Concrete(_))
+    }
+
+    /// Force resolution to a concrete value.
+    ///
+    /// For concrete values, returns a clone.
+    /// For lazy values, calls the resolver and returns the result.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the path doesn't exist in the data tree.
+    pub fn resolve(&self) -> Result<facet_value::Value> {
+        match self {
+            Self::Concrete(value) => Ok(value.clone()),
+            Self::Lazy { resolver, path } => resolver.resolve(path).ok_or_else(|| {
+                miette::miette!("Data path not found: {}", path)
+            }),
+        }
+    }
+
+    /// Try to resolve, returning None if the path doesn't exist.
+    pub fn try_resolve(&self) -> Option<facet_value::Value> {
+        match self {
+            Self::Concrete(value) => Some(value.clone()),
+            Self::Lazy { resolver, path } => resolver.resolve(path),
+        }
+    }
+
+    /// Access a field by name.
+    ///
+    /// For lazy values, this extends the path without resolving.
+    /// For concrete values, this performs normal field access.
+    pub fn field(&self, name: &str, span: crate::ast::Span, source: &TemplateSource) -> Result<LazyValue> {
+        match self {
+            Self::Lazy { resolver, path } => {
+                // Extend the path - don't resolve yet!
+                Ok(Self::Lazy {
+                    resolver: resolver.clone(),
+                    path: path.push(name),
+                })
+            }
+            Self::Concrete(value) => {
+                // Normal field access on concrete value
+                match value.destructure_ref() {
+                    DestructuredRef::Object(obj) => obj
+                        .get(name)
+                        .cloned()
+                        .map(Self::Concrete)
+                        .ok_or_else(|| {
+                            UnknownFieldError {
+                                base_type: "dict".to_string(),
+                                field: name.to_string(),
+                                known_fields: obj.keys().map(|k| k.to_string()).collect(),
+                                span,
+                                src: source.named_source(),
+                            }
+                            .into()
+                        }),
+                    _ => Err(TypeError {
+                        expected: "object or dict".to_string(),
+                        found: self.type_name().to_string(),
+                        context: "field access".to_string(),
+                        span,
+                        src: source.named_source(),
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+
+    /// Access an element by index.
+    ///
+    /// For lazy values, this extends the path with the index.
+    /// For concrete values, this performs normal index access.
+    pub fn index(&self, idx: i64, span: crate::ast::Span, source: &TemplateSource) -> Result<LazyValue> {
+        match self {
+            Self::Lazy { resolver, path } => {
+                // Extend the path with the index
+                Ok(Self::Lazy {
+                    resolver: resolver.clone(),
+                    path: path.push(idx.to_string()),
+                })
+            }
+            Self::Concrete(value) => {
+                match value.destructure_ref() {
+                    DestructuredRef::Array(arr) => {
+                        let i = if idx < 0 {
+                            (arr.len() as i64 + idx) as usize
+                        } else {
+                            idx as usize
+                        };
+                        arr.get(i).cloned().map(Self::Concrete).ok_or_else(|| {
+                            TypeError {
+                                expected: format!("index < {}", arr.len()),
+                                found: format!("index {i}"),
+                                context: "list index".to_string(),
+                                span,
+                                src: source.named_source(),
+                            }
+                            .into()
+                        })
+                    }
+                    _ => Err(TypeError {
+                        expected: "list".to_string(),
+                        found: self.type_name().to_string(),
+                        context: "index access".to_string(),
+                        span,
+                        src: source.named_source(),
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+
+    /// Access by string key (for object["key"] syntax).
+    pub fn index_str(&self, key: &str, span: crate::ast::Span, source: &TemplateSource) -> Result<LazyValue> {
+        match self {
+            Self::Lazy { resolver, path } => {
+                Ok(Self::Lazy {
+                    resolver: resolver.clone(),
+                    path: path.push(key),
+                })
+            }
+            Self::Concrete(value) => {
+                match value.destructure_ref() {
+                    DestructuredRef::Object(obj) => obj
+                        .get(key)
+                        .cloned()
+                        .map(Self::Concrete)
+                        .ok_or_else(|| {
+                            UnknownFieldError {
+                                base_type: "dict".to_string(),
+                                field: key.to_string(),
+                                known_fields: obj.keys().map(|k| k.to_string()).collect(),
+                                span,
+                                src: source.named_source(),
+                            }
+                            .into()
+                        }),
+                    _ => Err(TypeError {
+                        expected: "dict".to_string(),
+                        found: self.type_name().to_string(),
+                        context: "string index access".to_string(),
+                        span,
+                        src: source.named_source(),
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+
+    /// Get an iterator over (key, value) pairs.
+    ///
+    /// For lazy values, this resolves the keys but keeps values lazy.
+    /// For concrete values, this iterates normally.
+    pub fn iter_pairs(&self) -> Vec<(String, LazyValue)> {
+        match self {
+            Self::Lazy { resolver, path } => {
+                // Get keys at this path, but keep values lazy!
+                let keys = resolver.keys_at(path).unwrap_or_default();
+                keys.into_iter()
+                    .map(|key| {
+                        let child_path = path.push(&key);
+                        (
+                            key,
+                            Self::Lazy {
+                                resolver: resolver.clone(),
+                                path: child_path,
+                            },
+                        )
+                    })
+                    .collect()
+            }
+            Self::Concrete(value) => match value.destructure_ref() {
+                DestructuredRef::Object(obj) => obj
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), Self::Concrete(v.clone())))
+                    .collect(),
+                DestructuredRef::Array(arr) => arr
+                    .iter()
+                    .enumerate()
+                    .map(|(i, v)| (i.to_string(), Self::Concrete(v.clone())))
+                    .collect(),
+                _ => Vec::new(),
+            },
+        }
+    }
+
+    /// Get an iterator over values only (for simple for loops).
+    pub fn iter_values(&self) -> Vec<LazyValue> {
+        match self {
+            Self::Lazy { resolver, path } => {
+                let keys = resolver.keys_at(path).unwrap_or_default();
+                keys.into_iter()
+                    .map(|key| Self::Lazy {
+                        resolver: resolver.clone(),
+                        path: path.push(&key),
+                    })
+                    .collect()
+            }
+            Self::Concrete(value) => match value.destructure_ref() {
+                DestructuredRef::Array(arr) => {
+                    arr.iter().cloned().map(Self::Concrete).collect()
+                }
+                DestructuredRef::Object(obj) => {
+                    // For object iteration, return key-value pair objects
+                    obj.iter()
+                        .map(|(k, v)| {
+                            let mut entry = facet_value::VObject::new();
+                            entry.insert(
+                                facet_value::VString::from("key"),
+                                facet_value::Value::from(k.as_str()),
+                            );
+                            entry.insert(facet_value::VString::from("value"), v.clone());
+                            Self::Concrete(entry.into())
+                        })
+                        .collect()
+                }
+                DestructuredRef::String(s) => s
+                    .as_str()
+                    .chars()
+                    .map(|c| Self::Concrete(facet_value::Value::from(c.to_string().as_str())))
+                    .collect(),
+                _ => Vec::new(),
+            },
+        }
+    }
+
+    /// Check if the value is truthy (forces resolution for lazy values).
+    pub fn is_truthy(&self) -> bool {
+        match self.try_resolve() {
+            Some(v) => crate::eval::ValueExt::is_truthy(&v),
+            None => false,
+        }
+    }
+
+    /// Check if the value is null.
+    pub fn is_null(&self) -> bool {
+        match self.try_resolve() {
+            Some(v) => v.is_null(),
+            None => true, // Unresolvable paths are treated as null
+        }
+    }
+
+    /// Get a type name for error messages.
+    pub fn type_name(&self) -> &'static str {
+        match self {
+            Self::Lazy { .. } => "lazy",
+            Self::Concrete(v) => match v.destructure_ref() {
+                DestructuredRef::Null => "none",
+                DestructuredRef::Bool(_) => "bool",
+                DestructuredRef::Number(_) => "number",
+                DestructuredRef::String(_) => "string",
+                DestructuredRef::Bytes(_) => "bytes",
+                DestructuredRef::Array(_) => "list",
+                DestructuredRef::Object(_) => "dict",
+                DestructuredRef::DateTime(_) => "datetime",
+            },
+        }
+    }
+
+    /// Render the value to a string (forces resolution).
+    pub fn render_to_string(&self) -> String {
+        match self.try_resolve() {
+            Some(v) => crate::eval::ValueExt::render_to_string(&v),
+            None => String::new(),
+        }
+    }
+
+    /// Check if this value is marked as "safe" (forces resolution).
+    pub fn is_safe(&self) -> bool {
+        match self.try_resolve() {
+            Some(v) => crate::eval::ValueExt::is_safe(&v),
+            None => false,
+        }
+    }
+
+    /// Get the length of a container (may not require full resolution).
+    pub fn len(&self) -> Option<usize> {
+        match self {
+            Self::Lazy { resolver, path } => resolver.len_at(path),
+            Self::Concrete(value) => match value.destructure_ref() {
+                DestructuredRef::Array(arr) => Some(arr.len()),
+                DestructuredRef::Object(obj) => Some(obj.len()),
+                DestructuredRef::String(s) => Some(s.len()),
+                _ => None,
+            },
+        }
+    }
+
+    /// Check if the container is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len().map(|l| l == 0).unwrap_or(true)
+    }
+}
+
+// Conversion from facet_value::Value
+impl From<facet_value::Value> for LazyValue {
+    fn from(value: facet_value::Value) -> Self {
+        Self::Concrete(value)
+    }
+}
+
+// Convenience conversions
+impl From<&str> for LazyValue {
+    fn from(s: &str) -> Self {
+        Self::Concrete(facet_value::Value::from(s))
+    }
+}
+
+impl From<String> for LazyValue {
+    fn from(s: String) -> Self {
+        Self::Concrete(facet_value::Value::from(s.as_str()))
+    }
+}
+
+impl From<i64> for LazyValue {
+    fn from(n: i64) -> Self {
+        Self::Concrete(facet_value::Value::from(n))
+    }
+}
+
+impl From<f64> for LazyValue {
+    fn from(n: f64) -> Self {
+        Self::Concrete(facet_value::Value::from(n))
+    }
+}
+
+impl From<bool> for LazyValue {
+    fn from(b: bool) -> Self {
+        Self::Concrete(facet_value::Value::from(b))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use facet_value::{VObject, VString, Value};
+    use std::sync::Mutex;
+
+    fn test_span() -> crate::ast::Span {
+        crate::ast::span(0, 0)
+    }
+
+    /// A simple in-memory data resolver for testing.
+    struct TestResolver {
+        data: Value,
+        /// Track which paths were resolved (for testing)
+        resolved_paths: Mutex<Vec<DataPath>>,
+    }
+
+    impl TestResolver {
+        fn new(data: Value) -> Arc<Self> {
+            Arc::new(Self {
+                data,
+                resolved_paths: Mutex::new(Vec::new()),
+            })
+        }
+
+        fn resolved_paths(&self) -> Vec<DataPath> {
+            self.resolved_paths.lock().unwrap().clone()
+        }
+    }
+
+    impl DataResolver for TestResolver {
+        fn resolve(&self, path: &DataPath) -> Option<Value> {
+            self.resolved_paths.lock().unwrap().push(path.clone());
+
+            let mut current = self.data.clone();
+            for segment in path.segments() {
+                current = match current.destructure_ref() {
+                    DestructuredRef::Object(obj) => obj.get(segment.as_str())?.clone(),
+                    DestructuredRef::Array(arr) => {
+                        let idx: usize = segment.parse().ok()?;
+                        arr.get(idx)?.clone()
+                    }
+                    _ => return None,
+                };
+            }
+            Some(current)
+        }
+
+        fn keys_at(&self, path: &DataPath) -> Option<Vec<String>> {
+            let value = self.resolve(path)?;
+            match value.destructure_ref() {
+                DestructuredRef::Object(obj) => Some(obj.keys().map(|k| k.to_string()).collect()),
+                DestructuredRef::Array(arr) => Some((0..arr.len()).map(|i| i.to_string()).collect()),
+                _ => None,
+            }
+        }
+    }
+
+    fn make_test_data() -> Value {
+        let mut versions = VObject::new();
+
+        let mut dodeca = VObject::new();
+        dodeca.insert(VString::from("version"), Value::from("0.1.0"));
+        dodeca.insert(VString::from("name"), Value::from("Dodeca"));
+        versions.insert(VString::from("dodeca"), Value::from(dodeca));
+
+        let mut facet = VObject::new();
+        facet.insert(VString::from("version"), Value::from("0.2.0"));
+        versions.insert(VString::from("facet"), Value::from(facet));
+
+        let mut root = VObject::new();
+        root.insert(VString::from("versions"), Value::from(versions));
+        Value::from(root)
+    }
+
+    #[test]
+    fn test_data_path() {
+        let root = DataPath::root();
+        assert!(root.is_root());
+        assert_eq!(root.segments(), &[] as &[String]);
+
+        let child = root.push("versions");
+        assert!(!child.is_root());
+        assert_eq!(child.segments(), &["versions"]);
+
+        let grandchild = child.push("dodeca");
+        assert_eq!(grandchild.segments(), &["versions", "dodeca"]);
+    }
+
+    #[test]
+    fn test_lazy_field_access_extends_path() {
+        let resolver = TestResolver::new(make_test_data());
+        let lazy = LazyValue::lazy_root(resolver.clone());
+
+        // Field access should NOT resolve yet
+        let source = crate::error::TemplateSource::new("test", "");
+        let versions = lazy.field("versions", test_span(), &source).unwrap();
+
+        // Nothing should be resolved yet!
+        assert!(resolver.resolved_paths().is_empty());
+        assert!(versions.is_lazy());
+
+        // Further field access still doesn't resolve
+        let dodeca = versions.field("dodeca", test_span(), &source).unwrap();
+        assert!(resolver.resolved_paths().is_empty());
+
+        // Now resolve
+        let value = dodeca.field("version", test_span(), &source).unwrap();
+        let resolved = value.resolve().unwrap();
+
+        // NOW it should have resolved
+        assert_eq!(resolver.resolved_paths().len(), 1);
+        assert_eq!(
+            resolver.resolved_paths()[0].segments(),
+            &["versions", "dodeca", "version"]
+        );
+
+        // Check the value
+        if let DestructuredRef::String(s) = resolved.destructure_ref() {
+            assert_eq!(s.as_str(), "0.1.0");
+        } else {
+            panic!("Expected string");
+        }
+    }
+
+    #[test]
+    fn test_lazy_iteration() {
+        let resolver = TestResolver::new(make_test_data());
+        let lazy = LazyValue::lazy_root(resolver.clone());
+
+        let source = crate::error::TemplateSource::new("test", "");
+        let versions = lazy.field("versions", test_span(), &source).unwrap();
+
+        // Get pairs - this should resolve keys but NOT values
+        let pairs = versions.iter_pairs();
+        assert_eq!(pairs.len(), 2);
+
+        // Keys were resolved to get the list
+        assert_eq!(resolver.resolved_paths().len(), 1);
+
+        // But values are still lazy!
+        for (key, value) in &pairs {
+            assert!(value.is_lazy(), "Value for {} should be lazy", key);
+        }
+
+        // Now access one value
+        let (_, dodeca) = pairs.iter().find(|(k, _)| k == "dodeca").unwrap();
+        let version = dodeca.field("version", test_span(), &source).unwrap();
+        let _ = version.resolve().unwrap();
+
+        // Now we should have resolved the specific path
+        let paths = resolver.resolved_paths();
+        assert!(paths.iter().any(|p| p.segments() == &["versions", "dodeca", "version"]));
+    }
+
+    #[test]
+    fn test_concrete_value_access() {
+        let mut obj = VObject::new();
+        obj.insert(VString::from("name"), Value::from("test"));
+        let concrete = LazyValue::Concrete(Value::from(obj));
+
+        let source = crate::error::TemplateSource::new("test", "");
+        let name = concrete.field("name", test_span(), &source).unwrap();
+
+        // Should still be concrete
+        assert!(name.is_concrete());
+
+        let resolved = name.resolve().unwrap();
+        if let DestructuredRef::String(s) = resolved.destructure_ref() {
+            assert_eq!(s.as_str(), "test");
+        } else {
+            panic!("Expected string");
+        }
+    }
+
+    #[test]
+    fn test_render_to_string() {
+        let resolver = TestResolver::new(make_test_data());
+        let lazy = LazyValue::lazy_root(resolver.clone());
+
+        let source = crate::error::TemplateSource::new("test", "");
+        let version = lazy
+            .field("versions", test_span(), &source).unwrap()
+            .field("dodeca", test_span(), &source).unwrap()
+            .field("version", test_span(), &source).unwrap();
+
+        // render_to_string triggers resolution
+        assert_eq!(version.render_to_string(), "0.1.0");
+    }
+}

--- a/crates/gingembre/src/lib.rs
+++ b/crates/gingembre/src/lib.rs
@@ -42,11 +42,13 @@
 pub mod ast;
 mod error;
 mod eval;
+mod lazy;
 pub mod lexer;
 pub mod parser;
 mod render;
 
 pub use eval::{Context, GlobalFn, Value, ValueExt};
+pub use lazy::{DataPath, DataResolver, LazyValue};
 pub use render::{Engine, InMemoryLoader, TemplateLoader};
 
 // Re-export facet_value types for convenience

--- a/docs/design-lazy-data-loading.md
+++ b/docs/design-lazy-data-loading.md
@@ -1,0 +1,491 @@
+# Design: ULTIMATE Per-Value Lazy Data Loading
+
+This document proposes **per-value granularity** for lazy data loading - every single value access is individually tracked by Salsa.
+
+## The Vision
+
+```jinja
+{{ data.versions.dodeca.version }}
+```
+
+This should create a Salsa dependency on **exactly** `["versions", "dodeca", "version"]` - not the whole file, not even the whole `dodeca` object. Just that one value.
+
+Change `data.versions.dodeca.version`? Only pages using that exact path re-render.
+Change `data.versions.dodeca.name`? Pages using `.version` are untouched.
+
+## Core Concept: Lazy Paths
+
+Instead of resolving data eagerly, we track **paths** through the data tree. Resolution happens only when we need a concrete value (printing, comparison, iteration).
+
+```
+{{ data.versions.dodeca.version }}
+         ↓
+LazyValue { path: [] }
+         ↓ .versions
+LazyValue { path: ["versions"] }
+         ↓ .dodeca
+LazyValue { path: ["versions", "dodeca"] }
+         ↓ .version
+LazyValue { path: ["versions", "dodeca", "version"] }
+         ↓ {{ ... }} needs to print
+resolver.resolve(["versions", "dodeca", "version"])
+         ↓
+Salsa tracks THIS EXACT PATH as dependency
+```
+
+## Architecture
+
+### 1. LazyValue Type (gingembre)
+
+Replace direct `facet_value::Value` usage with a wrapper:
+
+```rust
+/// A value that may be lazily resolved.
+///
+/// Field access on lazy values extends the path rather than
+/// immediately resolving. Resolution happens when a concrete
+/// value is needed (printing, comparison, arithmetic, etc.)
+#[derive(Clone)]
+pub enum LazyValue {
+    /// A concrete, already-resolved value
+    Concrete(facet_value::Value),
+
+    /// A lazy reference that will be resolved on demand
+    Lazy {
+        /// The resolver that can fetch values by path
+        resolver: Arc<dyn DataResolver>,
+        /// The path through the data tree (e.g., ["versions", "dodeca", "version"])
+        path: DataPath,
+    },
+}
+
+/// A path through the data tree
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct DataPath(pub Vec<String>);
+
+impl DataPath {
+    pub fn root() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn push(&self, segment: impl Into<String>) -> Self {
+        let mut new_path = self.0.clone();
+        new_path.push(segment.into());
+        Self(new_path)
+    }
+}
+```
+
+### 2. DataResolver Trait (gingembre)
+
+```rust
+/// Trait for resolving data values by path.
+///
+/// Implementations should track dependencies - each unique path
+/// that is resolved becomes a separate dependency.
+pub trait DataResolver: Send + Sync {
+    /// Resolve a value at the given path.
+    /// Returns None if the path doesn't exist.
+    fn resolve(&self, path: &DataPath) -> Option<facet_value::Value>;
+
+    /// Get all child keys at a path (for iteration).
+    /// Returns None if the path doesn't exist or isn't an object/array.
+    fn keys_at(&self, path: &DataPath) -> Option<Vec<String>>;
+
+    /// Get the length at a path (for arrays).
+    fn len_at(&self, path: &DataPath) -> Option<usize>;
+}
+```
+
+### 3. LazyValue Operations
+
+```rust
+impl LazyValue {
+    /// Access a field - extends path for lazy values, normal access for concrete
+    pub fn field(&self, name: &str) -> Result<LazyValue> {
+        match self {
+            LazyValue::Concrete(value) => {
+                // Normal field access on concrete value
+                match value.destructure_ref() {
+                    DestructuredRef::Object(obj) => {
+                        obj.get(name)
+                            .cloned()
+                            .map(LazyValue::Concrete)
+                            .ok_or_else(|| /* error */)
+                    }
+                    _ => Err(/* type error */)
+                }
+            }
+            LazyValue::Lazy { resolver, path } => {
+                // Extend the path - don't resolve yet!
+                Ok(LazyValue::Lazy {
+                    resolver: resolver.clone(),
+                    path: path.push(name),
+                })
+            }
+        }
+    }
+
+    /// Index access - similar to field
+    pub fn index(&self, idx: usize) -> Result<LazyValue> {
+        match self {
+            LazyValue::Concrete(value) => { /* normal index */ }
+            LazyValue::Lazy { resolver, path } => {
+                Ok(LazyValue::Lazy {
+                    resolver: resolver.clone(),
+                    path: path.push(idx.to_string()),
+                })
+            }
+        }
+    }
+
+    /// Force resolution to a concrete value (for printing, comparison, etc.)
+    pub fn resolve(&self) -> Result<facet_value::Value> {
+        match self {
+            LazyValue::Concrete(value) => Ok(value.clone()),
+            LazyValue::Lazy { resolver, path } => {
+                resolver.resolve(path)
+                    .ok_or_else(|| /* undefined error */)
+            }
+        }
+    }
+
+    /// Check if truthy (forces resolution)
+    pub fn is_truthy(&self) -> bool {
+        self.resolve().map(|v| v.is_truthy()).unwrap_or(false)
+    }
+
+    /// Render to string (forces resolution)
+    pub fn render_to_string(&self) -> String {
+        self.resolve().map(|v| v.render_to_string()).unwrap_or_default()
+    }
+
+    /// Iterate over values (forces resolution of keys, lazy iteration of values)
+    pub fn iter(&self) -> impl Iterator<Item = (String, LazyValue)> {
+        match self {
+            LazyValue::Concrete(value) => {
+                // Normal iteration
+                match value.destructure_ref() {
+                    DestructuredRef::Object(obj) => {
+                        obj.iter()
+                            .map(|(k, v)| (k.to_string(), LazyValue::Concrete(v.clone())))
+                            .collect::<Vec<_>>()
+                            .into_iter()
+                    }
+                    DestructuredRef::Array(arr) => {
+                        arr.iter()
+                            .enumerate()
+                            .map(|(i, v)| (i.to_string(), LazyValue::Concrete(v.clone())))
+                            .collect::<Vec<_>>()
+                            .into_iter()
+                    }
+                    _ => Vec::new().into_iter()
+                }
+            }
+            LazyValue::Lazy { resolver, path } => {
+                // Get keys at this path, but keep values lazy!
+                let keys = resolver.keys_at(path).unwrap_or_default();
+                keys.into_iter()
+                    .map(|key| {
+                        let child_path = path.push(&key);
+                        (key, LazyValue::Lazy {
+                            resolver: resolver.clone(),
+                            path: child_path,
+                        })
+                    })
+                    .collect::<Vec<_>>()
+                    .into_iter()
+            }
+        }
+    }
+}
+```
+
+### 4. Salsa Integration (dodeca)
+
+The magic happens here. Each unique path becomes a separate Salsa query:
+
+```rust
+/// A path through the data tree, interned for efficient comparison
+#[salsa::interned]
+pub struct DataPathId<'db> {
+    pub segments: Vec<String>,
+}
+
+/// Resolve a value at a specific path - THIS IS THE KEY QUERY
+/// Each unique path is tracked separately by Salsa!
+#[salsa::tracked]
+pub fn resolve_data_path<'db>(
+    db: &'db dyn Db,
+    registry: DataRegistry,
+    path: DataPathId<'db>,
+) -> Option<Value> {
+    let segments = path.segments(db);
+
+    if segments.is_empty() {
+        // Root path - return object with all file keys
+        let mut obj = VObject::new();
+        for file in registry.files(db) {
+            let key = extract_filename_without_extension(file.path(db).as_str());
+            // Don't load the content here - just create the structure
+            obj.insert(VString::from(key), Value::NULL); // Placeholder
+        }
+        return Some(obj.into());
+    }
+
+    // First segment is the file name
+    let file_key = &segments[0];
+    let file = registry.files(db).iter()
+        .find(|f| extract_filename_without_extension(f.path(db).as_str()) == *file_key)?;
+
+    // Load and parse the file (tracked!)
+    let parsed = load_data_file(db, *file)?;
+
+    // Navigate to the specific path
+    let mut current = parsed;
+    for segment in segments.iter().skip(1) {
+        current = match current.destructure_ref() {
+            DestructuredRef::Object(obj) => obj.get(segment.as_str())?.clone(),
+            DestructuredRef::Array(arr) => {
+                let idx: usize = segment.parse().ok()?;
+                arr.get(idx)?.clone()
+            }
+            _ => return None,
+        };
+    }
+
+    Some(current)
+}
+
+/// Get child keys at a path (for iteration)
+#[salsa::tracked]
+pub fn data_keys_at<'db>(
+    db: &'db dyn Db,
+    registry: DataRegistry,
+    path: DataPathId<'db>,
+) -> Vec<String> {
+    let value = resolve_data_path(db, registry, path);
+    match value.as_ref().map(|v| v.destructure_ref()) {
+        Some(DestructuredRef::Object(obj)) => {
+            obj.keys().map(|k| k.to_string()).collect()
+        }
+        Some(DestructuredRef::Array(arr)) => {
+            (0..arr.len()).map(|i| i.to_string()).collect()
+        }
+        _ => Vec::new()
+    }
+}
+```
+
+### 5. SalsaDataResolver
+
+```rust
+/// A data resolver backed by Salsa queries.
+/// Each path resolution becomes a tracked dependency.
+pub struct SalsaDataResolver<'db> {
+    db: &'db dyn Db,
+    registry: DataRegistry,
+}
+
+impl<'db> SalsaDataResolver<'db> {
+    pub fn new(db: &'db dyn Db, registry: DataRegistry) -> Self {
+        Self { db, registry }
+    }
+
+    fn intern_path(&self, path: &DataPath) -> DataPathId<'db> {
+        DataPathId::new(self.db, path.0.clone())
+    }
+}
+
+impl gingembre::DataResolver for SalsaDataResolver<'_> {
+    fn resolve(&self, path: &DataPath) -> Option<facet_value::Value> {
+        let path_id = self.intern_path(path);
+        resolve_data_path(self.db, self.registry, path_id)
+    }
+
+    fn keys_at(&self, path: &DataPath) -> Option<Vec<String>> {
+        let path_id = self.intern_path(path);
+        let keys = data_keys_at(self.db, self.registry, path_id);
+        if keys.is_empty() { None } else { Some(keys) }
+    }
+
+    fn len_at(&self, path: &DataPath) -> Option<usize> {
+        self.keys_at(path).map(|k| k.len())
+    }
+}
+```
+
+## Context and Evaluator Changes
+
+### Context stores the resolver
+
+```rust
+pub struct Context {
+    scopes: Vec<HashMap<String, LazyValue>>,  // Changed from Value
+    global_fns: Arc<HashMap<String, Arc<GlobalFn>>>,
+    data_resolver: Option<Arc<dyn DataResolver>>,
+}
+
+impl Context {
+    /// Set up lazy data access
+    pub fn set_data_resolver(&mut self, resolver: Arc<dyn DataResolver>) {
+        // Create a lazy "data" variable pointing to root
+        self.set("data", LazyValue::Lazy {
+            resolver: resolver.clone(),
+            path: DataPath::root(),
+        });
+        self.data_resolver = Some(resolver);
+    }
+}
+```
+
+### Evaluator uses LazyValue
+
+```rust
+impl Evaluator {
+    pub fn eval(&self, expr: &Expr) -> Result<LazyValue> {
+        match expr {
+            Expr::Field(field) => {
+                let base = self.eval(&field.base)?;
+                base.field(&field.field.name)  // Extends path for lazy!
+            }
+            Expr::Index(index) => {
+                let base = self.eval(&index.base)?;
+                let idx = self.eval(&index.index)?.resolve()?;  // Need concrete index
+                // ... index access
+            }
+            Expr::Var(ident) => {
+                self.ctx.get(&ident.name)
+                    .cloned()
+                    .ok_or_else(|| /* undefined */)
+            }
+            // ... other cases
+        }
+    }
+}
+```
+
+## Dependency Graph Example
+
+Given `data/versions.toml`:
+```toml
+[dodeca]
+version = "0.1.0"
+name = "Dodeca"
+
+[facet]
+version = "0.2.0"
+```
+
+And template:
+```jinja
+{{ data.versions.dodeca.version }}
+```
+
+Salsa dependency graph:
+```
+render_page("/docs/install")
+    └── resolve_data_path(["versions", "dodeca", "version"])
+            └── load_data_file(versions.toml)
+```
+
+If we change `versions.toml` to update `dodeca.name`:
+- `load_data_file` result changes
+- `resolve_data_path(["versions", "dodeca", "version"])` is re-evaluated
+- But the **value** at that path hasn't changed!
+- Salsa sees same output → **no downstream invalidation**
+
+If we change `dodeca.version`:
+- `resolve_data_path(["versions", "dodeca", "version"])` returns different value
+- Pages using this path re-render
+
+## Iteration Granularity
+
+Even iteration is lazy:
+
+```jinja
+{% for name, info in data.versions %}
+  {{ info.version }}
+{% endfor %}
+```
+
+Creates dependencies:
+- `data_keys_at(["versions"])` → `["dodeca", "facet"]`
+- `resolve_data_path(["versions", "dodeca", "version"])`
+- `resolve_data_path(["versions", "facet", "version"])`
+
+If we add a new `[other]` section to versions.toml:
+- `data_keys_at(["versions"])` changes
+- Loop re-runs
+- But existing path resolutions may be cached!
+
+## Edge Cases
+
+### Truthiness checks
+
+```jinja
+{% if data.config.feature_enabled %}
+```
+
+This needs resolution to check truthiness. Creates dependency on full path.
+
+### Filters
+
+```jinja
+{{ data.items | length }}
+```
+
+The `length` filter needs to know the array/object size. This triggers `len_at()` which may not need full value resolution.
+
+### Comparisons
+
+```jinja
+{% if data.version == "1.0" %}
+```
+
+Both sides resolve. Comparison creates dependency.
+
+### Nested data access in functions
+
+```jinja
+{{ format_version(data.versions.dodeca) }}
+```
+
+The function receives a `LazyValue`. If it accesses `.version`, that creates a dependency.
+
+## Benefits
+
+1. **Maximum granularity**: Each unique path is individually tracked
+2. **Minimal invalidation**: Only re-render when the exact values used change
+3. **Lazy all the way down**: Even nested access doesn't resolve until needed
+4. **Composable**: Works with existing filters, functions, etc.
+
+## Trade-offs
+
+1. **More Salsa queries**: Each path = one query (but queries are cheap and cached)
+2. **LazyValue wrapper**: Some API changes in gingembre
+3. **Resolution overhead**: Extra indirection when accessing values
+4. **Interned paths**: Memory for path deduplication (negligible)
+
+## Implementation Plan
+
+### Phase 1: LazyValue in gingembre
+1. Add `LazyValue` enum and `DataPath` type
+2. Add `DataResolver` trait
+3. Update `Context` to use `LazyValue`
+4. Update `Evaluator` to work with `LazyValue`
+5. Add resolution points (printing, comparison, iteration)
+6. Tests
+
+### Phase 2: Salsa integration in dodeca
+1. Add `DataPathId` interned type
+2. Add `resolve_data_path` tracked query
+3. Add `data_keys_at` tracked query
+4. Implement `SalsaDataResolver`
+5. Update render functions
+6. Tests
+
+### Phase 3: Optimize
+1. Profile query overhead
+2. Consider path caching strategies
+3. Batch resolution for known patterns


### PR DESCRIPTION
## Summary

Implements fine-grained lazy data loading where each data path access (e.g., `data.versions.dodeca.version`) creates a separate Salsa tracked dependency. This enables precise incremental recomputation - changing one value in a data file only re-renders pages that actually access that specific value.

### How it works

- **LazyValue**: A new enum that's either `Concrete(Value)` or `Lazy { resolver, path }`
- **Field access extends the path**: `data.foo.bar` doesn't resolve immediately - it builds up the path `["foo", "bar"]`
- **Resolution happens on demand**: Only when a concrete value is needed (printing, comparison, iteration) does it call the resolver
- **Each path = one Salsa dependency**: `resolve_data_value(db, registry, path)` is a tracked query

### Changes

**gingembre:**
- `lazy.rs`: New module with `LazyValue`, `DataPath`, `DataResolver` trait
- `eval.rs`: Context stores `LazyValue`, evaluator returns lazy values
- `render.rs`: Updated for lazy iteration and variable binding

**dodeca:**
- `queries.rs`: `DataValuePath` interned type, `resolve_data_value`/`data_keys_at_path` tracked queries, `SalsaDataResolver`
- `render.rs`: New `*_with_resolver` functions, updated Salsa queries to use lazy loading

## Test plan

- [x] All gingembre tests pass (58 tests including new lazy loading tests)
- [x] All dodeca unit tests pass
- [x] Integration tests pass (25/26 - pagefind test failure is unrelated)
- [ ] Manual testing with a real site

Closes #97