### PR TITLE
feat: extract link checking to plugin (dodeca-linkcheck)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2168,6 +2168,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dodeca-linkcheck"
+version = "0.1.0"
+dependencies = [
+ "facet",
+ "linkme",
+ "plugcard",
+ "reqwest",
+ "url",
+]
+
+[[package]]
 name = "dodeca-minify"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "crates/gingembre", "crates/livereload-client", "crates/dodeca-devtools", "crates/dodeca-protocol", "crates/plugcard", "crates/plugcard-macros", "crates/dodeca-baseline", "crates/dodeca-webp", "crates/dodeca-jxl", "crates/dodeca-minify", "crates/dodeca-svgo", "crates/dodeca-sass", "crates/dodeca-css", "crates/dodeca-js", "crates/dodeca-pagefind", "crates/dodeca-image", "crates/dodeca-fonts", "xtask"]
+members = [".", "crates/gingembre", "crates/livereload-client", "crates/dodeca-devtools", "crates/dodeca-protocol", "crates/plugcard", "crates/plugcard-macros", "crates/dodeca-baseline", "crates/dodeca-webp", "crates/dodeca-jxl", "crates/dodeca-minify", "crates/dodeca-svgo", "crates/dodeca-sass", "crates/dodeca-css", "crates/dodeca-js", "crates/dodeca-pagefind", "crates/dodeca-image", "crates/dodeca-fonts", "crates/dodeca-linkcheck", "xtask"]
 
 [package]
 name = "dodeca"
@@ -94,9 +94,6 @@ dodeca-protocol = { path = "crates/dodeca-protocol" }
 # Content-addressed storage
 rapidhash = "4"
 canopydb = "0.2.5"
-
-# HTTP client (for external link checking)
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 
 # Date handling
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }

--- a/crates/dodeca-linkcheck/Cargo.toml
+++ b/crates/dodeca-linkcheck/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "dodeca-linkcheck"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.85"
+description = "External link checking plugin for dodeca"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+plugcard = { path = "../plugcard" }
+facet = { git = "https://github.com/facet-rs/facet" }
+linkme = "0.3"
+
+# HTTP client (blocking mode - no async runtime needed)
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
+
+# URL parsing for domain extraction
+url = "2"

--- a/crates/dodeca-linkcheck/src/lib.rs
+++ b/crates/dodeca-linkcheck/src/lib.rs
@@ -1,0 +1,210 @@
+//! External link checking plugin for dodeca
+//!
+//! Checks external URLs using blocking HTTP requests.
+//! Implements per-domain rate limiting to avoid hammering servers.
+
+use facet::Facet;
+use plugcard::{plugcard, PlugResult};
+use std::collections::{HashMap, HashSet};
+use std::time::{Duration, Instant};
+use url::Url;
+
+plugcard::export_plugin!();
+
+/// Status of an external link check
+#[derive(Facet, Debug, Clone, PartialEq, Eq)]
+pub struct LinkStatus {
+    /// "ok", "error", "failed", or "skipped"
+    pub status: String,
+    /// HTTP status code (for "error" status)
+    pub code: Option<u16>,
+    /// Error message (for "failed" status)
+    pub message: Option<String>,
+}
+
+impl LinkStatus {
+    pub fn ok() -> Self {
+        Self { status: "ok".to_string(), code: None, message: None }
+    }
+
+    pub fn error(code: u16) -> Self {
+        Self { status: "error".to_string(), code: Some(code), message: None }
+    }
+
+    pub fn failed(msg: String) -> Self {
+        Self { status: "failed".to_string(), code: None, message: Some(msg) }
+    }
+
+    pub fn skipped() -> Self {
+        Self { status: "skipped".to_string(), code: None, message: None }
+    }
+}
+
+/// Options for link checking
+#[derive(Facet, Debug, Clone)]
+pub struct CheckOptions {
+    /// Domains to skip checking
+    pub skip_domains: Vec<String>,
+    /// Minimum delay between requests to the same domain (milliseconds)
+    pub rate_limit_ms: u64,
+    /// Request timeout in seconds
+    pub timeout_secs: u64,
+}
+
+impl Default for CheckOptions {
+    fn default() -> Self {
+        Self {
+            skip_domains: Vec::new(),
+            rate_limit_ms: 1000,
+            timeout_secs: 10,
+        }
+    }
+}
+
+/// Result of checking multiple URLs
+#[derive(Facet, Debug, Clone)]
+pub struct CheckResult {
+    /// Status for each URL (in same order as input)
+    pub statuses: Vec<LinkStatus>,
+    /// Number of URLs that were actually checked (not skipped)
+    pub checked_count: u32,
+}
+
+/// Input for batch URL checking
+#[derive(Facet)]
+struct CheckUrlsInput {
+    urls: Vec<String>,
+    options: CheckOptions,
+}
+
+/// Check a batch of external URLs
+///
+/// Returns status for each URL in the same order as input.
+/// Uses blocking HTTP requests with per-domain rate limiting.
+#[plugcard]
+pub fn check_urls(urls: Vec<String>, options: CheckOptions) -> PlugResult<CheckResult> {
+    let skip_domains: HashSet<String> = options.skip_domains.iter().cloned().collect();
+    let rate_limit = Duration::from_millis(options.rate_limit_ms);
+    let timeout = Duration::from_secs(options.timeout_secs);
+
+    // Build HTTP client
+    let client = match reqwest::blocking::Client::builder()
+        .timeout(timeout)
+        .user_agent("dodeca-link-checker/1.0")
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => return PlugResult::Err(format!("Failed to build HTTP client: {e}")),
+    };
+
+    // Track last request time per domain for rate limiting
+    let mut domain_last_request: HashMap<String, Instant> = HashMap::new();
+    let mut statuses = Vec::with_capacity(urls.len());
+    let mut checked_count = 0u32;
+
+    for url in &urls {
+        // Extract domain
+        let domain = match Url::parse(url) {
+            Ok(u) => u.host_str().map(|s| s.to_string()),
+            Err(_) => None,
+        };
+
+        let Some(domain) = domain else {
+            statuses.push(LinkStatus::skipped());
+            continue;
+        };
+
+        // Check if domain should be skipped
+        if skip_domains.contains(&domain) {
+            statuses.push(LinkStatus::skipped());
+            continue;
+        }
+
+        // Apply rate limiting
+        if let Some(&last_request) = domain_last_request.get(&domain) {
+            let elapsed = last_request.elapsed();
+            if elapsed < rate_limit {
+                let wait_time = rate_limit - elapsed;
+                std::thread::sleep(wait_time);
+            }
+        }
+
+        // Make HTTP HEAD request
+        let status = check_single_url(&client, url);
+
+        // Update last request time
+        domain_last_request.insert(domain.clone(), Instant::now());
+
+        // Handle Retry-After for rate-limited responses
+        if status.code == Some(429) || status.code == Some(503) {
+            // Add extra delay for rate-limited responses
+            std::thread::sleep(Duration::from_secs(2));
+        }
+
+        checked_count += 1;
+        statuses.push(status);
+    }
+
+    PlugResult::Ok(CheckResult {
+        statuses,
+        checked_count,
+    })
+}
+
+/// Check a single URL
+fn check_single_url(client: &reqwest::blocking::Client, url: &str) -> LinkStatus {
+    match client.head(url).send() {
+        Ok(response) => {
+            let status_code = response.status().as_u16();
+            if (200..400).contains(&status_code) {
+                LinkStatus::ok()
+            } else {
+                LinkStatus::error(status_code)
+            }
+        }
+        Err(e) => LinkStatus::failed(e.to_string()),
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn debug_struct_size() -> usize {
+    std::mem::size_of::<plugcard::MethodSignature>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_check_urls_skips_invalid() {
+        let urls = vec!["not-a-url".to_string()];
+        let options = CheckOptions::default();
+
+        let result = check_urls(urls, options);
+        let PlugResult::Ok(result) = result else {
+            panic!("Expected Ok");
+        };
+
+        assert_eq!(result.statuses.len(), 1);
+        assert_eq!(result.statuses[0], LinkStatus::skipped());
+        assert_eq!(result.checked_count, 0);
+    }
+
+    #[test]
+    fn test_check_urls_skips_domains() {
+        let urls = vec!["https://example.com/page".to_string()];
+        let options = CheckOptions {
+            skip_domains: vec!["example.com".to_string()],
+            ..Default::default()
+        };
+
+        let result = check_urls(urls, options);
+        let PlugResult::Ok(result) = result else {
+            panic!("Expected Ok");
+        };
+
+        assert_eq!(result.statuses.len(), 1);
+        assert_eq!(result.statuses[0], LinkStatus::skipped());
+        assert_eq!(result.checked_count, 0);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,5 +7,6 @@ pub mod error_pages;
 pub mod file_watcher;
 pub mod html_diff;
 pub mod link_checker;
+pub mod plugins;
 pub mod template;
 pub mod types;


### PR DESCRIPTION
## Summary
- Extracted external link checking from main binary to `dodeca-linkcheck` plugin
- Removed `reqwest` dependency from main binary (keeping it as dev-dependency for tests)
- Plugin uses blocking HTTP with per-domain rate limiting via `std::thread::sleep`
- Main binary wraps plugin call in `spawn_blocking` to avoid blocking async runtime

## Test plan
- [x] All link checker tests pass (`cargo test -p dodeca -- link_checker`)
- [x] Plugin tests pass (`cargo test -p dodeca-linkcheck`)
- [x] Full build works (`cargo xtask build`)

Closes #105