### PR TITLE
docs: add template debugging and Sass/SCSS guides

### DIFF
--- a/docs/content/guide/debugging-templates.md
+++ b/docs/content/guide/debugging-templates.md
@@ -1,0 +1,189 @@
++++
+title = "Debugging Templates"
+description = "How to debug template issues in dodeca"
+weight = 60
++++
+
+When templates don't render as expected, here's how to diagnose and fix the problem.
+
+## Inspecting variables
+
+Print a variable's type and value:
+
+```jinja
+DEBUG: {{ some_var }} (type: {{ some_var | typeof }})
+```
+
+The `typeof` filter returns: `"string"`, `"number"`, `"none"`, `"list"`, `"dict"`, `"bool"`.
+
+Check if a variable is defined:
+
+```jinja
+{% if some_var is defined %}
+  Has value: {{ some_var }}
+{% else %}
+  Variable is undefined
+{% endif %}
+```
+
+## Available context
+
+### In page templates (`page.html`)
+
+```jinja
+{{ page.title }}        {# Page title #}
+{{ page.content }}      {# Rendered HTML body #}
+{{ page.permalink }}    {# URL path like "/guide/intro" #}
+{{ page.weight }}       {# Sort order #}
+{{ page.toc }}          {# Table of contents (list of headings) #}
+{{ page.ancestors }}    {# Breadcrumb chain (list of sections) #}
+{{ page.last_updated }} {# Last modification timestamp #}
+{{ page.extra }}        {# Custom frontmatter fields #}
+
+{{ section.title }}     {# Parent section #}
+{{ section.pages }}     {# Sibling pages #}
+```
+
+### In section templates (`section.html`, `index.html`)
+
+```jinja
+{{ section.title }}       {# Section title #}
+{{ section.content }}     {# Rendered HTML body from _index.md #}
+{{ section.permalink }}   {# URL path #}
+{{ section.pages }}       {# Pages in this section (sorted by weight) #}
+{{ section.subsections }} {# Child sections #}
+{{ section.toc }}         {# Table of contents #}
+{{ section.extra }}       {# Custom frontmatter fields #}
+```
+
+### Global variables (all templates)
+
+```jinja
+{{ config.title }}       {# Site title #}
+{{ config.base_url }}    {# Base URL #}
+{{ current_path }}       {# Current page's path #}
+{{ root }}               {# Root section (for navigation) #}
+{{ data }}               {# Custom data files (if any) #}
+```
+
+## Common gotchas
+
+### Lists vs single values
+
+Iterating over something that isn't a list:
+
+```jinja
+{# This fails if page.extra.tags is a string, not a list #}
+{% for tag in page.extra.tags %}
+  {{ tag }}
+{% endfor %}
+
+{# Check first #}
+{% if page.extra.tags is defined %}
+  {% for tag in page.extra.tags %}
+    {{ tag }}
+  {% endfor %}
+{% endif %}
+```
+
+### None vs empty string vs undefined
+
+These are all different:
+
+```jinja
+{% if value is undefined %}     {# Variable doesn't exist at all #}
+{% if value is defined %}       {# Variable exists (might be none/empty) #}
+{% if value %}                  {# Truthy: not none, not empty, not 0 #}
+{% if value is empty %}         {# Empty string "" or empty list [] #}
+```
+
+Use `default` filter for fallbacks:
+
+```jinja
+{{ page.description | default(value="No description") }}
+```
+
+### Filter order matters
+
+Filters apply left to right:
+
+```jinja
+{{ items | first | upper }}     {# Get first, then uppercase it #}
+{{ items | sort | first }}      {# Sort first, then get first #}
+```
+
+### Accessing nested fields
+
+Use dot notation:
+
+```jinja
+{{ page.extra.author }}
+{{ section.subsections | first | attr(name="title") }}
+```
+
+## Reading error messages
+
+Dodeca provides detailed error diagnostics. Example:
+
+```
+Error: template::unknown_field
+
+  × Unknown field `titl` on object
+   ╭─[templates/page.html:5:1]
+ 5 │ <h1>{{ page.titl }}</h1>
+   ·              ──┬─
+   ·                ╰── unknown field
+   ╰────
+  help: Available fields: title, content, permalink, path, weight, toc, ancestors, last_updated, extra
+```
+
+The error shows:
+- **Error type**: `unknown_field` - you're accessing something that doesn't exist
+- **Location**: `templates/page.html:5` - file and line number
+- **Context**: The actual template code with the problem highlighted
+- **Help**: Available alternatives
+
+## Template inheritance issues
+
+When using `{% extends "base.html" %}`:
+
+1. The child template must define blocks that exist in the parent
+2. Content outside blocks is ignored in child templates
+3. Use `{{ super() }}` to include parent block content
+
+```jinja
+{% extends "base.html" %}
+
+{% block content %}
+  {{ super() }}  {# Include parent's content block first #}
+  <p>Additional content</p>
+{% endblock %}
+```
+
+## Useful filters for debugging
+
+```jinja
+{{ value | typeof }}              {# Get type name #}
+{{ items | length }}              {# Count items #}
+{{ object | keys }}               {# List object keys (if supported) #}
+{{ items | first }}               {# First element #}
+{{ items | last }}                {# Last element #}
+{{ text | escape }}               {# HTML-escape for safe display #}
+```
+
+## Quick reference: available tests
+
+Use with `is` in conditions:
+
+```jinja
+{% if value is defined %}
+{% if value is undefined %}
+{% if value is string %}
+{% if value is number %}
+{% if value is empty %}
+{% if value is odd %}
+{% if value is even %}
+{% if value is truthy %}
+{% if path is starting_with("/admin") %}
+{% if text is containing("search") %}
+```

--- a/docs/content/guide/sass.md
+++ b/docs/content/guide/sass.md
@@ -1,0 +1,129 @@
++++
+title = "Sass/SCSS"
+description = "Using Sass stylesheets in dodeca"
+weight = 50
++++
+
+Dodeca compiles Sass/SCSS stylesheets automatically.
+
+## Directory structure
+
+Place your Sass files in a `sass/` directory at your project root:
+
+```
+my-site/
+├── .config/
+│   └── dodeca.kdl
+├── content/
+├── sass/
+│   ├── main.scss        # Entry point (required)
+│   ├── _variables.scss  # Partial (not compiled directly)
+│   └── _components.scss # Another partial
+├── static/
+└── templates/
+```
+
+## Entry point
+
+The file `sass/main.scss` is the entry point. This is the only file that gets compiled directly - all other styles should be imported from here.
+
+If `main.scss` doesn't exist, SCSS compilation is skipped (no error).
+
+## Partials
+
+Files starting with `_` are partials. They're not compiled on their own but can be imported:
+
+```scss
+// _variables.scss
+$primary-color: #3498db;
+$font-stack: system-ui, sans-serif;
+
+// _components.scss
+.button {
+  background: $primary-color;
+  padding: 0.5rem 1rem;
+}
+```
+
+Import them in `main.scss` using `@use`:
+
+```scss
+// main.scss
+@use "variables";
+@use "components";
+
+body {
+  font-family: variables.$font-stack;
+  color: variables.$primary-color;
+}
+```
+
+Note: Use `@use` (modern Sass) rather than `@import` (deprecated).
+
+## Using in templates
+
+Reference the compiled CSS in your templates:
+
+```html
+<link rel="stylesheet" href="/main.css">
+```
+
+Dodeca automatically:
+1. Compiles `sass/main.scss` to CSS
+2. Rewrites URLs inside the CSS (for images, fonts, etc.)
+3. Adds a content hash for cache busting (e.g., `/main.a1b2c3d4.css`)
+4. Serves `/main.css` with a redirect to the hashed version
+
+## Live reload
+
+When you modify any `.scss` file during `ddc serve`:
+
+1. The file change is detected
+2. SCSS is recompiled
+3. A CSS-specific live reload message is sent
+4. The browser updates styles without a full page reload
+
+This makes style iteration fast - you'll see changes almost instantly.
+
+## Cache busting
+
+The compiled CSS gets a content-based hash in its filename:
+
+- Source: `sass/main.scss`
+- Output: `main.0a3dec24.css` (hash changes when content changes)
+
+This means browsers can cache the CSS forever, but will always fetch new versions when you deploy changes.
+
+## URL rewriting
+
+URLs in your CSS (for backgrounds, fonts, etc.) are automatically rewritten to point to the correct cache-busted paths:
+
+```scss
+// Input
+.hero {
+  background: url('/images/hero.jpg');
+}
+
+// Output (after compilation)
+.hero {
+  background: url('/images/hero.dec0da12.jpg');
+}
+```
+
+## Troubleshooting
+
+### SCSS not compiling
+
+- Check that `sass/main.scss` exists (exact name required)
+- Check the terminal for compilation errors
+
+### Styles not updating
+
+- Hard refresh the browser (Cmd+Shift+R / Ctrl+Shift+R)
+- Check that live reload is connected (look for WebSocket connection in browser dev tools)
+- Try `ddc clean` to clear caches, then restart `ddc serve`
+
+### Import errors
+
+- Use `@use "filename"` without the `_` prefix or `.scss` extension
+- Partials must be in the same `sass/` directory


### PR DESCRIPTION
## Summary

- Add template debugging guide covering available context variables, common gotchas, and error message interpretation
- Add Sass/SCSS usage guide covering directory structure, partials, live reload, and cache busting

## Notes

These are the two documentation issues that **cannot be automated** via facet-docs (see facet-rs/facet#1188):

- #77 (template debugging) - conceptual guide about debugging techniques
- #79 (Sass/SCSS) - documents conventions and workflows, not struct fields

The remaining documentation issues (#75, #76, #80, #81) document struct fields and should be generated from code once facet-docs is implemented.

## Test plan

- [x] Verify docs render correctly with `ddc serve` in the docs directory
- [x] Check links and formatting

Closes #77, closes #79