### PR TITLE
feat: add rapace crate for async RPC over shared memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3095,6 +3095,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "gingembre-types"
+version = "0.1.0"
+dependencies = [
+ "facet",
+ "facet-value",
+]
+
+[[package]]
 name = "glade"
 version = "0.1.0"
 source = "git+https://github.com/bearcove/glade#773bd62c424ec24239028be5c64e0bc57f789cb1"
@@ -6720,6 +6728,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rapace"
+version = "0.1.0"
+dependencies = [
+ "facet",
+ "facet-postcard",
+ "libc",
+ "paste",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,11 +2,13 @@
 members = [
     "crates/dodeca",
     "crates/gingembre",
+    "crates/gingembre-types",
     "crates/livereload-client",
     "crates/dodeca-devtools",
     "crates/dodeca-protocol",
     "crates/plugcard",
     "crates/plugcard-macros",
+    "crates/rapace",
     "crates/dodeca-baseline",
     "crates/dodeca-webp",
     "crates/dodeca-jxl",

--- a/crates/rapace/Cargo.toml
+++ b/crates/rapace/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "rapace"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.85"
+license = "MIT OR Apache-2.0"
+description = "Async RPC over functions or sockets"
+
+[dependencies]
+facet = { git = "https://github.com/facet-rs/facet" }
+facet-postcard = { git = "https://github.com/facet-rs/facet" }
+tokio = { version = "1", features = ["sync", "io-util", "rt", "rt-multi-thread", "macros", "time"] }
+paste = "1"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"

--- a/crates/rapace/examples/shm_common/mod.rs
+++ b/crates/rapace/examples/shm_common/mod.rs
@@ -1,0 +1,19 @@
+//! Shared service definitions for the shm examples
+//!
+//! This module defines the HostService and PluginService interfaces
+//! that are used by both shm_host and shm_plugin examples.
+
+// Host service - provides data to plugin
+rapace::service! {
+    pub trait HostService {
+        async fn load_template(name: String) -> Option<String>;
+        async fn resolve_data(path: String) -> Option<String>;
+    }
+}
+
+// Plugin service - renders templates
+rapace::service! {
+    pub trait PluginService {
+        async fn render(template_name: String) -> String;
+    }
+}

--- a/crates/rapace/examples/shm_host.rs
+++ b/crates/rapace/examples/shm_host.rs
@@ -1,0 +1,91 @@
+//! Host side of the shared memory example
+//!
+//! Run this first, it will print the shared memory name.
+//! Then run shm_plugin with that name as an argument.
+//!
+//! Usage: cargo run --example shm_host
+
+mod shm_common;
+
+use rapace::shm::{SharedMemoryChannel, DEFAULT_RING_CAPACITY};
+use shm_common::{dispatch_host_service, HostService, PluginServiceClient};
+use std::time::Duration;
+
+struct Host;
+
+impl HostService for Host {
+    async fn load_template(&self, name: String) -> Option<String> {
+        println!("[host] load_template({:?})", name);
+        match name.as_str() {
+            "greeting.html" => Some("Hello, {{ name }}!".to_string()),
+            "base.html" => Some("<html>{% block content %}{% endblock %}</html>".to_string()),
+            _ => None,
+        }
+    }
+
+    async fn resolve_data(&self, path: String) -> Option<String> {
+        println!("[host] resolve_data({:?})", path);
+        match path.as_str() {
+            "user.name" => Some("Alice".to_string()),
+            "user.email" => Some("alice@example.com".to_string()),
+            _ => None,
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    // Create shared memory
+    let channel = SharedMemoryChannel::new(DEFAULT_RING_CAPACITY).expect("Failed to create shm");
+    let shm_name = channel.name().to_string();
+    println!("Shared memory created: {}", shm_name);
+    println!("Run: cargo run --example shm_plugin -- {}", shm_name);
+
+    // Host: writes to ring_a, reads from ring_b
+    let (conn, mut incoming) = rapace::shm::run(channel.ring_a(), channel.ring_b()).await;
+
+    // Create client to call plugin
+    let plugin_client = PluginServiceClient::new(conn.clone());
+
+    // Spawn handler for incoming HostService requests from plugin
+    let host_service = Host;
+    let conn_for_handler = conn.clone();
+    tokio::spawn(async move {
+        while let Some((id, payload)) = incoming.recv().await {
+            println!("[host] Received request id={}", id);
+            match dispatch_host_service(&host_service, &payload).await {
+                Ok(response) => {
+                    let _ = conn_for_handler.respond(id, response).await;
+                }
+                Err(e) => {
+                    eprintln!("[host] Error dispatching: {:?}", e);
+                }
+            }
+        }
+    });
+
+    // Wait for plugin to connect
+    println!("[host] Waiting for plugin (10 seconds)...");
+    tokio::time::sleep(Duration::from_secs(10)).await;
+
+    // Call the plugin
+    println!("[host] Calling plugin.render(\"greeting.html\")...");
+    match tokio::time::timeout(
+        Duration::from_secs(10),
+        plugin_client.render("greeting.html".to_string()),
+    )
+    .await
+    {
+        Ok(Ok(result)) => {
+            println!("[host] Result: {}", result);
+        }
+        Ok(Err(e)) => {
+            eprintln!("[host] Error: {:?}", e);
+        }
+        Err(_) => {
+            eprintln!("[host] Timeout waiting for response");
+        }
+    }
+
+    println!("[host] Done");
+}

--- a/crates/rapace/examples/shm_plugin.rs
+++ b/crates/rapace/examples/shm_plugin.rs
@@ -1,0 +1,93 @@
+//! Plugin side of the shared memory example
+//!
+//! Run shm_host first to create the shared memory, then run this with the shm name.
+//!
+//! Usage: cargo run --example shm_plugin -- /rapace-12345-67890
+
+mod shm_common;
+
+use rapace::shm::{SharedMemoryChannel, DEFAULT_RING_CAPACITY};
+use shm_common::{dispatch_plugin_service, HostServiceClient, PluginService};
+
+struct Plugin {
+    host_client: HostServiceClient,
+}
+
+impl PluginService for Plugin {
+    async fn render(&self, template_name: String) -> String {
+        println!("[plugin] render({:?})", template_name);
+
+        // Call back to host to load the template
+        println!("[plugin] Calling host.load_template...");
+        let template = match self.host_client.load_template(template_name.clone()).await {
+            Ok(t) => t,
+            Err(e) => {
+                eprintln!("[plugin] Error loading template: {:?}", e);
+                return format!("Error: {:?}", e);
+            }
+        };
+
+        match template {
+            Some(t) => {
+                // Call back to host to resolve data
+                println!("[plugin] Calling host.resolve_data...");
+                let name = self
+                    .host_client
+                    .resolve_data("user.name".to_string())
+                    .await
+                    .ok()
+                    .flatten()
+                    .unwrap_or_else(|| "World".to_string());
+
+                // Simple "render"
+                t.replace("{{ name }}", &name)
+            }
+            None => format!("Template not found: {}", template_name),
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 2 {
+        eprintln!("Usage: {} <shm_name>", args[0]);
+        eprintln!("Example: {} /rapace-12345-67890", args[0]);
+        std::process::exit(1);
+    }
+
+    let shm_name = &args[1];
+    println!("[plugin] Opening shared memory: {}", shm_name);
+
+    // Open existing shared memory
+    let channel =
+        SharedMemoryChannel::open(shm_name, DEFAULT_RING_CAPACITY).expect("Failed to open shm");
+
+    // Plugin: reads from ring_a, writes to ring_b (opposite of host!)
+    let (conn, mut incoming) = rapace::shm::run(channel.ring_b(), channel.ring_a()).await;
+
+    // Create client to call host
+    let host_client = HostServiceClient::new(conn.clone());
+
+    // Create plugin service
+    let plugin_service = Plugin { host_client };
+
+    // Handle incoming PluginService requests from host
+    let conn_for_handler = conn.clone();
+    println!("[plugin] Ready, waiting for requests...");
+
+    while let Some((id, payload)) = incoming.recv().await {
+        println!("[plugin] Received request id={}", id);
+        match dispatch_plugin_service(&plugin_service, &payload).await {
+            Ok(response) => {
+                println!("[plugin] Sending response for id={}", id);
+                let _ = conn_for_handler.respond(id, response).await;
+            }
+            Err(e) => {
+                eprintln!("[plugin] Error dispatching: {:?}", e);
+            }
+        }
+    }
+
+    println!("[plugin] Connection closed");
+}

--- a/crates/rapace/src/lib.rs
+++ b/crates/rapace/src/lib.rs
@@ -1,0 +1,299 @@
+//! Rapace: Async RPC over functions or sockets
+//!
+//! A minimal async RPC system that works over:
+//! - Function pointers (same-process, for .so plugins)
+//! - Sockets/pipes (separate process or remote)
+//!
+//! # Wire Protocol
+//!
+//! Messages are length-prefixed frames:
+//! ```text
+//! [length: u32 little-endian][frame: postcard-encoded Frame]
+//! ```
+//!
+//! Each frame has an ID for request/response correlation, allowing
+//! multiple concurrent calls in both directions.
+
+pub mod service;
+#[cfg(unix)]
+pub mod shm;
+pub mod socket;
+
+// Re-exports for macro use
+pub use facet_postcard;
+pub use paste;
+
+use facet::Facet;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use tokio::sync::{mpsc, oneshot, Mutex};
+
+/// A frame on the wire
+#[derive(Facet, Debug, Clone)]
+pub struct Frame {
+    /// Unique ID for request/response correlation
+    pub id: u64,
+    /// What kind of frame this is
+    pub kind: FrameKind,
+    /// The payload (another postcard-encoded message)
+    pub payload: Vec<u8>,
+}
+
+/// The kind of frame
+#[derive(Facet, Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum FrameKind {
+    /// A request expecting a response
+    Request = 0,
+    /// A response to a request
+    Response = 1,
+    /// A one-way notification (no response expected)
+    Notification = 2,
+}
+
+/// Encode a frame to bytes (length-prefixed)
+pub fn encode_frame(frame: &Frame) -> Result<Vec<u8>, EncodeError> {
+    let frame_bytes = facet_postcard::to_vec(frame).map_err(|_| EncodeError::Serialize)?;
+    let len = frame_bytes.len() as u32;
+    let mut buf = Vec::with_capacity(4 + frame_bytes.len());
+    buf.extend_from_slice(&len.to_le_bytes());
+    buf.extend_from_slice(&frame_bytes);
+    Ok(buf)
+}
+
+/// Decode a frame from bytes (expects length prefix already stripped)
+pub fn decode_frame(bytes: &[u8]) -> Result<Frame, DecodeError> {
+    facet_postcard::from_bytes(bytes).map_err(|_| DecodeError::Deserialize)
+}
+
+/// Read the length prefix from a buffer, returns (length, bytes_consumed)
+pub fn read_length_prefix(buf: &[u8]) -> Option<(u32, usize)> {
+    if buf.len() < 4 {
+        return None;
+    }
+    let len = u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]);
+    Some((len, 4))
+}
+
+#[derive(Debug)]
+pub enum EncodeError {
+    Serialize,
+}
+
+#[derive(Debug)]
+pub enum DecodeError {
+    Deserialize,
+    Incomplete,
+}
+
+/// Pending requests waiting for responses
+type PendingRequests = Arc<Mutex<HashMap<u64, oneshot::Sender<Vec<u8>>>>>;
+
+/// Inner state of a connection (shared via Arc)
+struct ConnectionInner {
+    /// Send frames out
+    tx: mpsc::Sender<Frame>,
+    /// Counter for generating unique request IDs
+    next_id: AtomicU64,
+    /// Pending requests waiting for responses
+    pending: PendingRequests,
+}
+
+/// A connection that can send and receive frames
+#[derive(Clone)]
+pub struct Connection {
+    inner: Arc<ConnectionInner>,
+}
+
+impl Connection {
+    /// Create a new connection with the given sender
+    ///
+    /// Returns the connection and a receiver that should be used to feed
+    /// incoming frames (call `handle_incoming` for each received frame)
+    pub fn new() -> (Self, mpsc::Receiver<Frame>) {
+        let (tx, rx) = mpsc::channel(64);
+        let inner = ConnectionInner {
+            tx,
+            next_id: AtomicU64::new(1),
+            pending: Arc::new(Mutex::new(HashMap::new())),
+        };
+        let conn = Self {
+            inner: Arc::new(inner),
+        };
+        (conn, rx)
+    }
+
+    /// Access pending requests (for transport implementations)
+    pub fn pending(&self) -> &PendingRequests {
+        &self.inner.pending
+    }
+
+    /// Send a request and wait for the response
+    pub async fn request(&self, payload: Vec<u8>) -> Result<Vec<u8>, RequestError> {
+        let id = self.inner.next_id.fetch_add(1, Ordering::Relaxed);
+
+        // Set up the response channel before sending
+        let (response_tx, response_rx) = oneshot::channel();
+        {
+            let mut pending = self.inner.pending.lock().await;
+            pending.insert(id, response_tx);
+        }
+
+        // Send the request
+        let frame = Frame {
+            id,
+            kind: FrameKind::Request,
+            payload,
+        };
+        self.inner
+            .tx
+            .send(frame)
+            .await
+            .map_err(|_| RequestError::SendFailed)?;
+
+        // Wait for response
+        response_rx.await.map_err(|_| RequestError::Cancelled)
+    }
+
+    /// Send a notification (fire-and-forget)
+    pub async fn notify(&self, payload: Vec<u8>) -> Result<(), RequestError> {
+        let id = self.inner.next_id.fetch_add(1, Ordering::Relaxed);
+        let frame = Frame {
+            id,
+            kind: FrameKind::Notification,
+            payload,
+        };
+        self.inner
+            .tx
+            .send(frame)
+            .await
+            .map_err(|_| RequestError::SendFailed)
+    }
+
+    /// Send a response to a request
+    pub async fn respond(&self, request_id: u64, payload: Vec<u8>) -> Result<(), RequestError> {
+        let frame = Frame {
+            id: request_id,
+            kind: FrameKind::Response,
+            payload,
+        };
+        self.inner
+            .tx
+            .send(frame)
+            .await
+            .map_err(|_| RequestError::SendFailed)
+    }
+
+    /// Handle an incoming frame (call this when you receive a frame)
+    ///
+    /// Returns Some((id, payload)) if this is a request that needs handling,
+    /// None if it was a response (already dispatched to waiter)
+    pub async fn handle_incoming(&self, frame: Frame) -> Option<(u64, Vec<u8>)> {
+        match frame.kind {
+            FrameKind::Response => {
+                // Find and notify the waiter
+                let mut pending = self.inner.pending.lock().await;
+                if let Some(tx) = pending.remove(&frame.id) {
+                    let _ = tx.send(frame.payload);
+                }
+                None
+            }
+            FrameKind::Request => {
+                // Return to caller for handling
+                Some((frame.id, frame.payload))
+            }
+            FrameKind::Notification => {
+                // Return to caller for handling (id is ignored for notifications)
+                Some((frame.id, frame.payload))
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum RequestError {
+    SendFailed,
+    Cancelled,
+}
+
+impl std::fmt::Display for RequestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RequestError::SendFailed => write!(f, "failed to send request"),
+            RequestError::Cancelled => write!(f, "request cancelled"),
+        }
+    }
+}
+
+impl std::error::Error for RequestError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_frame_roundtrip() {
+        let frame = Frame {
+            id: 42,
+            kind: FrameKind::Request,
+            payload: b"hello world".to_vec(),
+        };
+
+        let encoded = encode_frame(&frame).unwrap();
+
+        // Check length prefix
+        let (len, consumed) = read_length_prefix(&encoded).unwrap();
+        assert_eq!(consumed, 4);
+
+        // Decode the frame
+        let decoded = decode_frame(&encoded[4..4 + len as usize]).unwrap();
+        assert_eq!(decoded.id, 42);
+        assert_eq!(decoded.kind, FrameKind::Request);
+        assert_eq!(decoded.payload, b"hello world");
+    }
+
+    #[tokio::test]
+    async fn test_request_response() {
+        let (conn1, mut rx1) = Connection::new();
+        let (conn2, mut rx2) = Connection::new();
+
+        // Spawn handler for conn2's outgoing (which is conn1's incoming)
+        let conn1_pending = conn1.pending().clone();
+        let handle1 = tokio::spawn(async move {
+            while let Some(frame) = rx2.recv().await {
+                // This is a frame from conn2, deliver to conn1
+                let mut pending = conn1_pending.lock().await;
+                if frame.kind == FrameKind::Response {
+                    if let Some(tx) = pending.remove(&frame.id) {
+                        let _ = tx.send(frame.payload);
+                    }
+                }
+            }
+        });
+
+        // Spawn handler for conn1's outgoing (which is conn2's incoming)
+        let conn2_clone = conn2.clone();
+        let handle2 = tokio::spawn(async move {
+            while let Some(frame) = rx1.recv().await {
+                // This is a request from conn1, handle it
+                if frame.kind == FrameKind::Request {
+                    // Echo back with "response: " prefix
+                    let mut response = b"response: ".to_vec();
+                    response.extend_from_slice(&frame.payload);
+                    let _ = conn2_clone.respond(frame.id, response).await;
+                }
+            }
+        });
+
+        // Send a request from conn1
+        let response = conn1.request(b"hello".to_vec()).await.unwrap();
+        assert_eq!(response, b"response: hello");
+
+        // Clean up
+        drop(conn1);
+        drop(conn2);
+        let _ = handle1.await;
+        let _ = handle2.await;
+    }
+}

--- a/crates/rapace/src/service.rs
+++ b/crates/rapace/src/service.rs
@@ -1,0 +1,319 @@
+//! Service macro for defining typed RPC interfaces
+//!
+//! # Example
+//!
+//! ```ignore
+//! rapace::service! {
+//!     pub trait MyService {
+//!         async fn greet(name: String) -> String;
+//!         async fn add(a: i32, b: i32) -> i32;
+//!     }
+//! }
+//! ```
+//!
+//! This generates:
+//! - `MyServiceRequest` enum with variants for each method
+//! - `MyServiceResponse` enum with variants for each method
+//! - `MyServiceClient` struct with async methods that send requests
+//! - `MyService` trait that you implement to handle requests
+
+/// Define a service interface with typed request/response
+///
+/// Each method becomes a request/response pair, serialized with Facet.
+#[macro_export]
+macro_rules! service {
+    (
+        $(#[$trait_attr:meta])*
+        $vis:vis trait $name:ident {
+            $(
+                $(#[$method_attr:meta])*
+                async fn $method:ident($($arg:ident: $arg_ty:ty),* $(,)?) -> $ret:ty;
+            )*
+        }
+    ) => {
+        $crate::service!(@paste
+            $(#[$trait_attr])*
+            $vis trait $name {
+                $(
+                    $(#[$method_attr])*
+                    async fn $method($($arg: $arg_ty),*) -> $ret;
+                )*
+            }
+        );
+    };
+
+    (@paste
+        $(#[$trait_attr:meta])*
+        $vis:vis trait $name:ident {
+            $(
+                $(#[$method_attr:meta])*
+                async fn $method:ident($($arg:ident: $arg_ty:ty),*) -> $ret:ty;
+            )*
+        }
+    ) => {
+        $crate::paste::paste! {
+            // Request enum
+            #[derive(::facet::Facet, Debug)]
+            #[repr(u8)]
+            $vis enum [<$name Request>] {
+                $(
+                    [<$method:camel>] { $($arg: $arg_ty),* },
+                )*
+            }
+
+            // Response enum
+            #[derive(::facet::Facet, Debug)]
+            #[repr(u8)]
+            $vis enum [<$name Response>] {
+                $(
+                    [<$method:camel>]($ret),
+                )*
+            }
+
+            // Service trait
+            $(#[$trait_attr])*
+            $vis trait $name {
+                $(
+                    $(#[$method_attr])*
+                    fn $method(&self, $($arg: $arg_ty),*) -> impl std::future::Future<Output = $ret> + Send;
+                )*
+            }
+
+            // Client struct
+            $vis struct [<$name Client>] {
+                conn: $crate::Connection,
+            }
+
+            impl [<$name Client>] {
+                /// Create a new client wrapping a connection
+                pub fn new(conn: $crate::Connection) -> Self {
+                    Self { conn }
+                }
+
+                $(
+                    $(#[$method_attr])*
+                    pub async fn $method(&self, $($arg: $arg_ty),*) -> Result<$ret, $crate::RequestError> {
+                        let request = [<$name Request>]::[<$method:camel>] { $($arg),* };
+                        let request_bytes = $crate::facet_postcard::to_vec(&request)
+                            .map_err(|_| $crate::RequestError::SendFailed)?;
+                        let response_bytes = self.conn.request(request_bytes).await?;
+                        let response: [<$name Response>] = $crate::facet_postcard::from_bytes(&response_bytes)
+                            .map_err(|_| $crate::RequestError::Cancelled)?;
+                        match response {
+                            [<$name Response>]::[<$method:camel>](v) => Ok(v),
+                            #[allow(unreachable_patterns)]
+                            _ => Err($crate::RequestError::Cancelled),
+                        }
+                    }
+                )*
+            }
+
+            // Server dispatch function
+            $vis async fn [<dispatch_ $name:snake>]<S: $name>(
+                service: &S,
+                request_bytes: &[u8],
+            ) -> Result<Vec<u8>, $crate::RequestError> {
+                let request: [<$name Request>] = $crate::facet_postcard::from_bytes(request_bytes)
+                    .map_err(|_| $crate::RequestError::Cancelled)?;
+                let response = match request {
+                    $(
+                        [<$name Request>]::[<$method:camel>] { $($arg),* } => {
+                            let result = service.$method($($arg),*).await;
+                            [<$name Response>]::[<$method:camel>](result)
+                        }
+                    )*
+                };
+                $crate::facet_postcard::to_vec(&response)
+                    .map_err(|_| $crate::RequestError::SendFailed)
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::duplex;
+
+    // Define a test service
+    crate::service! {
+        pub trait Calculator {
+            async fn add(a: i32, b: i32) -> i32;
+            async fn greet(name: String) -> String;
+        }
+    }
+
+    // Implement the service
+    struct CalculatorImpl;
+
+    impl Calculator for CalculatorImpl {
+        async fn add(&self, a: i32, b: i32) -> i32 {
+            a + b
+        }
+
+        async fn greet(&self, name: String) -> String {
+            format!("Hello, {}!", name)
+        }
+    }
+
+    #[tokio::test]
+    async fn test_service_macro() {
+        // Create a bidirectional pipe
+        let (client_stream, server_stream) = duplex(64 * 1024);
+        let (client_read, client_write) = tokio::io::split(client_stream);
+        let (server_read, server_write) = tokio::io::split(server_stream);
+
+        // Set up client side
+        let (client_conn, _) = crate::socket::run(client_read, client_write).await.unwrap();
+        let client = CalculatorClient::new(client_conn);
+
+        // Set up server side
+        let (server_conn, mut server_incoming) =
+            crate::socket::run(server_read, server_write).await.unwrap();
+        let service = CalculatorImpl;
+
+        // Spawn server handler
+        tokio::spawn(async move {
+            while let Some((id, payload)) = server_incoming.recv().await {
+                let response = dispatch_calculator(&service, &payload).await.unwrap();
+                let _ = server_conn.respond(id, response).await;
+            }
+        });
+
+        // Test add
+        let result = client.add(2, 3).await.unwrap();
+        assert_eq!(result, 5);
+
+        // Test greet
+        let result = client.greet("World".to_string()).await.unwrap();
+        assert_eq!(result, "Hello, World!");
+    }
+
+    // =========================================================================
+    // Test bidirectional services - like host/plugin communication
+    // =========================================================================
+
+    // Host service - provides data to plugin
+    crate::service! {
+        pub trait HostService {
+            async fn load_template(name: String) -> Option<String>;
+            async fn resolve_data(path: String) -> Option<String>;
+        }
+    }
+
+    // Plugin service - renders templates
+    crate::service! {
+        pub trait PluginService {
+            async fn render(template_name: String) -> String;
+        }
+    }
+
+    // Host implementation
+    struct Host;
+
+    impl HostService for Host {
+        async fn load_template(&self, name: String) -> Option<String> {
+            match name.as_str() {
+                "greeting.html" => Some("Hello, {{ name }}!".to_string()),
+                "base.html" => Some("<html>{% block content %}{% endblock %}</html>".to_string()),
+                _ => None,
+            }
+        }
+
+        async fn resolve_data(&self, path: String) -> Option<String> {
+            match path.as_str() {
+                "user.name" => Some("Alice".to_string()),
+                "user.email" => Some("alice@example.com".to_string()),
+                _ => None,
+            }
+        }
+    }
+
+    // Plugin implementation - calls BACK to host to get templates/data
+    struct Plugin {
+        host_client: HostServiceClient,
+    }
+
+    impl PluginService for Plugin {
+        async fn render(&self, template_name: String) -> String {
+            // Call back to host to load the template
+            let template = self
+                .host_client
+                .load_template(template_name.clone())
+                .await
+                .unwrap();
+
+            match template {
+                Some(t) => {
+                    // Call back to host to resolve data
+                    let name = self
+                        .host_client
+                        .resolve_data("user.name".to_string())
+                        .await
+                        .unwrap()
+                        .unwrap_or_else(|| "World".to_string());
+
+                    // "Render" by simple replacement
+                    t.replace("{{ name }}", &name)
+                }
+                None => format!("Template not found: {}", template_name),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_bidirectional_services() {
+        // Create bidirectional pipe
+        let (host_stream, plugin_stream) = duplex(64 * 1024);
+        let (host_read, host_write) = tokio::io::split(host_stream);
+        let (plugin_read, plugin_write) = tokio::io::split(plugin_stream);
+
+        // Set up host side connection
+        let (host_conn, mut host_incoming) =
+            crate::socket::run(host_read, host_write).await.unwrap();
+
+        // Set up plugin side connection
+        let (plugin_conn, mut plugin_incoming) =
+            crate::socket::run(plugin_read, plugin_write).await.unwrap();
+
+        // Host is a client to PluginService
+        let plugin_client = PluginServiceClient::new(host_conn.clone());
+
+        // Plugin is a client to HostService
+        let host_client = HostServiceClient::new(plugin_conn.clone());
+
+        // Host service implementation
+        let host_service = Host;
+
+        // Plugin service implementation (with reference back to host)
+        let plugin_service = Plugin { host_client };
+
+        // Spawn host's request handler (handles HostService requests from plugin)
+        let host_conn_for_handler = host_conn.clone();
+        tokio::spawn(async move {
+            while let Some((id, payload)) = host_incoming.recv().await {
+                let response = dispatch_host_service(&host_service, &payload).await.unwrap();
+                let _ = host_conn_for_handler.respond(id, response).await;
+            }
+        });
+
+        // Spawn plugin's request handler (handles PluginService requests from host)
+        let plugin_conn_for_handler = plugin_conn.clone();
+        tokio::spawn(async move {
+            while let Some((id, payload)) = plugin_incoming.recv().await {
+                let response = dispatch_plugin_service(&plugin_service, &payload)
+                    .await
+                    .unwrap();
+                let _ = plugin_conn_for_handler.respond(id, response).await;
+            }
+        });
+
+        // Now the host can call the plugin to render
+        // The plugin will call BACK to the host to get template and data
+        let result = plugin_client.render("greeting.html".to_string()).await.unwrap();
+        assert_eq!(result, "Hello, Alice!");
+
+        // Try with missing template
+        let result = plugin_client.render("missing.html".to_string()).await.unwrap();
+        assert_eq!(result, "Template not found: missing.html");
+    }
+}

--- a/crates/rapace/src/shm.rs
+++ b/crates/rapace/src/shm.rs
@@ -1,0 +1,550 @@
+//! Shared memory ring buffer transport
+//!
+//! A lock-free, single-producer single-consumer ring buffer in shared memory.
+//! Used for fast local communication between host and plugin.
+//!
+//! # Memory Layout
+//!
+//! ```text
+//! [Ring A: host → plugin][Ring B: plugin → host]
+//!
+//! Each ring:
+//! ┌─────────────────────────────────────────────────────────┐
+//! │ head: AtomicU64 │ tail: AtomicU64 │ data: [u8; capacity] │
+//! └─────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! - `head`: write position (updated by producer)
+//! - `tail`: read position (updated by consumer)
+//! - Ring is empty when head == tail
+//! - Ring is full when (head + 1) % capacity == tail
+//!
+//! Messages are length-prefixed: [len: u32][data: [u8; len]]
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::{io, ptr};
+
+/// Size of ring buffer header (head + tail pointers)
+const RING_HEADER_SIZE: usize = 16; // 2 * size_of::<AtomicU64>()
+
+/// Default ring buffer capacity (data portion)
+pub const DEFAULT_RING_CAPACITY: usize = 64 * 1024; // 64 KB
+
+/// Total size needed for a ring buffer
+pub const fn ring_total_size(capacity: usize) -> usize {
+    RING_HEADER_SIZE + capacity
+}
+
+/// Total size needed for the shared memory region (two rings)
+pub const fn shm_total_size(ring_capacity: usize) -> usize {
+    2 * ring_total_size(ring_capacity)
+}
+
+/// A ring buffer in shared memory
+pub struct Ring {
+    /// Pointer to the start of this ring's memory
+    base: *mut u8,
+    /// Capacity of the data portion
+    capacity: usize,
+}
+
+// Safety: Ring uses atomic operations for synchronization
+unsafe impl Send for Ring {}
+unsafe impl Sync for Ring {}
+
+impl Ring {
+    /// Create a Ring from a pointer to its memory region
+    ///
+    /// # Safety
+    /// - `base` must point to a valid memory region of at least `ring_total_size(capacity)` bytes
+    /// - The memory must be properly aligned for AtomicU64
+    /// - The memory must remain valid for the lifetime of this Ring
+    pub unsafe fn from_ptr(base: *mut u8, capacity: usize) -> Self {
+        Self { base, capacity }
+    }
+
+    /// Initialize the ring (call once when creating shared memory)
+    pub fn init(&self) {
+        self.head().store(0, Ordering::Release);
+        self.tail().store(0, Ordering::Release);
+    }
+
+    fn head(&self) -> &AtomicU64 {
+        unsafe { &*(self.base as *const AtomicU64) }
+    }
+
+    fn tail(&self) -> &AtomicU64 {
+        unsafe { &*((self.base as *const AtomicU64).add(1)) }
+    }
+
+    fn data(&self) -> *mut u8 {
+        unsafe { self.base.add(RING_HEADER_SIZE) }
+    }
+
+    /// Available space for writing
+    pub fn write_available(&self) -> usize {
+        let head = self.head().load(Ordering::Acquire);
+        let tail = self.tail().load(Ordering::Acquire);
+        if head >= tail {
+            self.capacity - (head - tail) as usize - 1
+        } else {
+            (tail - head) as usize - 1
+        }
+    }
+
+    /// Available data for reading
+    pub fn read_available(&self) -> usize {
+        let head = self.head().load(Ordering::Acquire);
+        let tail = self.tail().load(Ordering::Acquire);
+        if head >= tail {
+            (head - tail) as usize
+        } else {
+            self.capacity - (tail - head) as usize
+        }
+    }
+
+    /// Write a message to the ring (length-prefixed)
+    ///
+    /// Returns Ok(()) if written, Err if not enough space
+    pub fn write_message(&self, data: &[u8]) -> Result<(), WriteError> {
+        let msg_len = data.len();
+        let total_len = 4 + msg_len; // length prefix + data
+
+        if total_len > self.write_available() {
+            return Err(WriteError::Full);
+        }
+
+        let head = self.head().load(Ordering::Acquire) as usize;
+        let capacity = self.capacity;
+
+        // Write length prefix
+        let len_bytes = (msg_len as u32).to_le_bytes();
+        self.write_bytes_at(head, &len_bytes, capacity);
+
+        // Write data
+        self.write_bytes_at((head + 4) % capacity, data, capacity);
+
+        // Update head
+        let new_head = (head + total_len) % capacity;
+        self.head().store(new_head as u64, Ordering::Release);
+
+        Ok(())
+    }
+
+    fn write_bytes_at(&self, pos: usize, data: &[u8], capacity: usize) {
+        let data_ptr = self.data();
+        let first_chunk = (capacity - pos).min(data.len());
+
+        unsafe {
+            ptr::copy_nonoverlapping(data.as_ptr(), data_ptr.add(pos), first_chunk);
+            if first_chunk < data.len() {
+                // Wrap around
+                ptr::copy_nonoverlapping(
+                    data.as_ptr().add(first_chunk),
+                    data_ptr,
+                    data.len() - first_chunk,
+                );
+            }
+        }
+    }
+
+    /// Read a message from the ring
+    ///
+    /// Returns Ok(Some(data)) if a message was read, Ok(None) if ring is empty
+    pub fn read_message(&self) -> Result<Option<Vec<u8>>, ReadError> {
+        if self.read_available() < 4 {
+            return Ok(None);
+        }
+
+        let tail = self.tail().load(Ordering::Acquire) as usize;
+        let capacity = self.capacity;
+
+        // Read length prefix
+        let mut len_bytes = [0u8; 4];
+        self.read_bytes_at(tail, &mut len_bytes, capacity);
+        let msg_len = u32::from_le_bytes(len_bytes) as usize;
+
+        let total_len = 4 + msg_len;
+        if self.read_available() < total_len {
+            // Incomplete message (shouldn't happen with proper writes)
+            return Err(ReadError::Incomplete);
+        }
+
+        // Read data
+        let mut data = vec![0u8; msg_len];
+        self.read_bytes_at((tail + 4) % capacity, &mut data, capacity);
+
+        // Update tail
+        let new_tail = (tail + total_len) % capacity;
+        self.tail().store(new_tail as u64, Ordering::Release);
+
+        Ok(Some(data))
+    }
+
+    fn read_bytes_at(&self, pos: usize, buf: &mut [u8], capacity: usize) {
+        let data_ptr = self.data();
+        let first_chunk = (capacity - pos).min(buf.len());
+
+        unsafe {
+            ptr::copy_nonoverlapping(data_ptr.add(pos), buf.as_mut_ptr(), first_chunk);
+            if first_chunk < buf.len() {
+                // Wrap around
+                ptr::copy_nonoverlapping(
+                    data_ptr,
+                    buf.as_mut_ptr().add(first_chunk),
+                    buf.len() - first_chunk,
+                );
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum WriteError {
+    Full,
+}
+
+#[derive(Debug)]
+pub enum ReadError {
+    Incomplete,
+}
+
+/// Shared memory channel - owns the memory and provides both rings
+pub struct SharedMemoryChannel {
+    /// The shared memory region
+    mem: SharedMemory,
+    /// Capacity of each ring's data portion
+    ring_capacity: usize,
+}
+
+impl SharedMemoryChannel {
+    /// Create a new shared memory channel
+    pub fn new(ring_capacity: usize) -> io::Result<Self> {
+        let total_size = shm_total_size(ring_capacity);
+        let mem = SharedMemory::create(total_size)?;
+
+        let channel = Self { mem, ring_capacity };
+
+        // Initialize both rings
+        channel.ring_a().init();
+        channel.ring_b().init();
+
+        Ok(channel)
+    }
+
+    /// Open an existing shared memory channel by name/fd
+    pub fn open(name: &str, ring_capacity: usize) -> io::Result<Self> {
+        let total_size = shm_total_size(ring_capacity);
+        let mem = SharedMemory::open(name, total_size)?;
+        Ok(Self { mem, ring_capacity })
+    }
+
+    /// Get the name/path for sharing with another process
+    pub fn name(&self) -> &str {
+        self.mem.name()
+    }
+
+    /// Ring A: typically host → plugin
+    pub fn ring_a(&self) -> Ring {
+        unsafe { Ring::from_ptr(self.mem.ptr(), self.ring_capacity) }
+    }
+
+    /// Ring B: typically plugin → host
+    pub fn ring_b(&self) -> Ring {
+        let offset = ring_total_size(self.ring_capacity);
+        unsafe { Ring::from_ptr(self.mem.ptr().add(offset), self.ring_capacity) }
+    }
+}
+
+/// Platform-specific shared memory implementation
+struct SharedMemory {
+    ptr: *mut u8,
+    size: usize,
+    name: String,
+    #[cfg(unix)]
+    fd: std::os::unix::io::RawFd,
+}
+
+impl SharedMemory {
+    #[cfg(unix)]
+    fn create(size: usize) -> io::Result<Self> {
+        use std::ffi::CString;
+        use std::os::unix::io::RawFd;
+
+        // Generate unique name
+        let name = format!("/rapace-{}-{}", std::process::id(), rand_u64());
+        let c_name = CString::new(name.clone()).unwrap();
+
+        unsafe {
+            // Create shared memory object
+            let fd: RawFd = libc::shm_open(
+                c_name.as_ptr(),
+                libc::O_CREAT | libc::O_RDWR | libc::O_EXCL,
+                0o600,
+            );
+            if fd < 0 {
+                return Err(io::Error::last_os_error());
+            }
+
+            // Set size
+            if libc::ftruncate(fd, size as libc::off_t) < 0 {
+                libc::close(fd);
+                libc::shm_unlink(c_name.as_ptr());
+                return Err(io::Error::last_os_error());
+            }
+
+            // Map it
+            let ptr = libc::mmap(
+                ptr::null_mut(),
+                size,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_SHARED,
+                fd,
+                0,
+            );
+            if ptr == libc::MAP_FAILED {
+                libc::close(fd);
+                libc::shm_unlink(c_name.as_ptr());
+                return Err(io::Error::last_os_error());
+            }
+
+            Ok(Self {
+                ptr: ptr as *mut u8,
+                size,
+                name,
+                fd,
+            })
+        }
+    }
+
+    #[cfg(unix)]
+    fn open(name: &str, size: usize) -> io::Result<Self> {
+        use std::ffi::CString;
+        use std::os::unix::io::RawFd;
+
+        let c_name = CString::new(name).unwrap();
+
+        unsafe {
+            let fd: RawFd = libc::shm_open(c_name.as_ptr(), libc::O_RDWR, 0);
+            if fd < 0 {
+                return Err(io::Error::last_os_error());
+            }
+
+            let ptr = libc::mmap(
+                ptr::null_mut(),
+                size,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_SHARED,
+                fd,
+                0,
+            );
+            if ptr == libc::MAP_FAILED {
+                libc::close(fd);
+                return Err(io::Error::last_os_error());
+            }
+
+            Ok(Self {
+                ptr: ptr as *mut u8,
+                size,
+                name: name.to_string(),
+                fd,
+            })
+        }
+    }
+
+    fn ptr(&self) -> *mut u8 {
+        self.ptr
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+#[cfg(unix)]
+impl Drop for SharedMemory {
+    fn drop(&mut self) {
+        unsafe {
+            libc::munmap(self.ptr as *mut libc::c_void, self.size);
+            libc::close(self.fd);
+            // Only unlink if we created it (has our PID in the name)
+            let our_prefix = format!("/rapace-{}-", std::process::id());
+            if self.name.starts_with(&our_prefix) {
+                let c_name = std::ffi::CString::new(self.name.clone()).unwrap();
+                libc::shm_unlink(c_name.as_ptr());
+            }
+        }
+    }
+}
+
+fn rand_u64() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let duration = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+    duration.as_nanos() as u64 ^ (duration.as_secs() << 32)
+}
+
+// =============================================================================
+// Async transport over shared memory
+// =============================================================================
+
+use crate::{Connection, FrameKind, decode_frame, encode_frame};
+use tokio::sync::mpsc;
+use std::time::Duration;
+
+/// Run a connection over shared memory rings
+///
+/// - `outgoing_ring`: Ring to write outgoing messages to
+/// - `incoming_ring`: Ring to read incoming messages from
+///
+/// Returns a Connection and a receiver for incoming requests/notifications.
+pub async fn run(
+    outgoing_ring: Ring,
+    incoming_ring: Ring,
+) -> (Connection, mpsc::Receiver<(u64, Vec<u8>)>) {
+    let (conn, mut conn_outgoing) = Connection::new();
+    let (incoming_tx, incoming_rx) = mpsc::channel(64);
+
+    let pending = conn.pending().clone();
+
+    // Spawn writer task - polls the outgoing channel and writes to ring
+    tokio::spawn(async move {
+        while let Some(frame) = conn_outgoing.recv().await {
+            let encoded = match encode_frame(&frame) {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+
+            // Spin until we can write (or use a more sophisticated backpressure)
+            loop {
+                match outgoing_ring.write_message(&encoded) {
+                    Ok(()) => break,
+                    Err(WriteError::Full) => {
+                        // Ring full, yield and retry
+                        tokio::task::yield_now().await;
+                    }
+                }
+            }
+        }
+    });
+
+    // Spawn reader task - polls the incoming ring and dispatches
+    tokio::spawn(async move {
+        loop {
+            match incoming_ring.read_message() {
+                Ok(Some(msg)) => {
+                    // Skip the length prefix that encode_frame added
+                    // (ring already stripped its own length prefix)
+                    if msg.len() < 4 {
+                        continue;
+                    }
+                    let frame_data = &msg[4..];
+                    if let Ok(frame) = decode_frame(frame_data) {
+                        match frame.kind {
+                            FrameKind::Response => {
+                                let mut pending = pending.lock().await;
+                                if let Some(tx) = pending.remove(&frame.id) {
+                                    let _ = tx.send(frame.payload);
+                                }
+                            }
+                            FrameKind::Request | FrameKind::Notification => {
+                                let _ = incoming_tx.send((frame.id, frame.payload)).await;
+                            }
+                        }
+                    }
+                }
+                Ok(None) => {
+                    // No message available, poll again after short sleep
+                    tokio::time::sleep(Duration::from_micros(10)).await;
+                }
+                Err(_) => {
+                    // Error reading, sleep and retry
+                    tokio::time::sleep(Duration::from_millis(1)).await;
+                }
+            }
+        }
+    });
+
+    (conn, incoming_rx)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ring_buffer_basic() {
+        let channel = SharedMemoryChannel::new(1024).unwrap();
+        let ring = channel.ring_a();
+
+        // Write a message
+        ring.write_message(b"hello").unwrap();
+        assert_eq!(ring.read_available(), 9); // 4 (len) + 5 (data)
+
+        // Read it back
+        let msg = ring.read_message().unwrap().unwrap();
+        assert_eq!(msg, b"hello");
+
+        // Ring should be empty
+        assert!(ring.read_message().unwrap().is_none());
+    }
+
+    #[test]
+    fn test_ring_buffer_multiple_messages() {
+        let channel = SharedMemoryChannel::new(1024).unwrap();
+        let ring = channel.ring_a();
+
+        // Write multiple messages
+        ring.write_message(b"one").unwrap();
+        ring.write_message(b"two").unwrap();
+        ring.write_message(b"three").unwrap();
+
+        // Read them back in order
+        assert_eq!(ring.read_message().unwrap().unwrap(), b"one");
+        assert_eq!(ring.read_message().unwrap().unwrap(), b"two");
+        assert_eq!(ring.read_message().unwrap().unwrap(), b"three");
+        assert!(ring.read_message().unwrap().is_none());
+    }
+
+    #[test]
+    fn test_ring_buffer_wrap_around() {
+        let channel = SharedMemoryChannel::new(64).unwrap(); // Small buffer to force wrap
+        let ring = channel.ring_a();
+
+        // Fill and drain several times to test wrap-around
+        for i in 0..10 {
+            let msg = format!("message-{}", i);
+            ring.write_message(msg.as_bytes()).unwrap();
+            let read = ring.read_message().unwrap().unwrap();
+            assert_eq!(read, msg.as_bytes());
+        }
+    }
+
+    #[test]
+    fn test_bidirectional() {
+        let channel = SharedMemoryChannel::new(1024).unwrap();
+
+        // Host writes to ring_a, plugin reads from ring_a
+        // Plugin writes to ring_b, host reads from ring_b
+        let host_to_plugin = channel.ring_a();
+        let plugin_to_host = channel.ring_b();
+
+        host_to_plugin.write_message(b"request").unwrap();
+        assert_eq!(
+            host_to_plugin.read_message().unwrap().unwrap(),
+            b"request"
+        );
+
+        plugin_to_host.write_message(b"response").unwrap();
+        assert_eq!(
+            plugin_to_host.read_message().unwrap().unwrap(),
+            b"response"
+        );
+    }
+
+    // =========================================================================
+    // NOTE: A bidirectional shm test with services requires two separate processes
+    // because Ring is SPSC (single producer, single consumer). In a single process,
+    // multiple readers would race on the same ring.
+    //
+    // See examples/shm_host.rs and examples/shm_plugin.rs for the proper cross-process test.
+}

--- a/crates/rapace/src/socket.rs
+++ b/crates/rapace/src/socket.rs
@@ -1,0 +1,140 @@
+//! Socket transport for separate-process communication
+//!
+//! Works over any AsyncRead + AsyncWrite (TCP, Unix sockets, pipes, etc.)
+
+use crate::{decode_frame, encode_frame, Connection, FrameKind};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::sync::mpsc;
+
+/// Run a connection over a socket
+///
+/// This spawns two tasks:
+/// - One to read frames from the socket and dispatch them
+/// - One to write outgoing frames to the socket
+///
+/// Returns a Connection you can use to send requests.
+pub async fn run<R, W>(
+    mut reader: R,
+    mut writer: W,
+) -> std::io::Result<(Connection, mpsc::Receiver<(u64, Vec<u8>)>)>
+where
+    R: AsyncRead + Unpin + Send + 'static,
+    W: AsyncWrite + Unpin + Send + 'static,
+{
+    let (conn, mut outgoing_rx) = Connection::new();
+    let (incoming_tx, incoming_rx) = mpsc::channel(64);
+
+    let pending = conn.pending().clone();
+
+    // Spawn writer task
+    tokio::spawn(async move {
+        while let Some(frame) = outgoing_rx.recv().await {
+            let encoded = match encode_frame(&frame) {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+            if writer.write_all(&encoded).await.is_err() {
+                break;
+            }
+        }
+    });
+
+    // Spawn reader task
+    tokio::spawn(async move {
+        let mut buf = vec![0u8; 64 * 1024];
+        let mut filled = 0usize;
+
+        loop {
+            // Read more data
+            let n = match reader.read(&mut buf[filled..]).await {
+                Ok(0) => break, // EOF
+                Ok(n) => n,
+                Err(_) => break,
+            };
+            filled += n;
+
+            // Try to parse frames
+            let mut consumed = 0;
+            while consumed + 4 <= filled {
+                let len_bytes = &buf[consumed..consumed + 4];
+                let frame_len =
+                    u32::from_le_bytes([len_bytes[0], len_bytes[1], len_bytes[2], len_bytes[3]])
+                        as usize;
+
+                if consumed + 4 + frame_len > filled {
+                    // Not enough data yet
+                    break;
+                }
+
+                let frame_bytes = &buf[consumed + 4..consumed + 4 + frame_len];
+                if let Ok(frame) = decode_frame(frame_bytes) {
+                    match frame.kind {
+                        FrameKind::Response => {
+                            // Dispatch to waiting request
+                            let mut pending = pending.lock().await;
+                            if let Some(tx) = pending.remove(&frame.id) {
+                                let _ = tx.send(frame.payload);
+                            }
+                        }
+                        FrameKind::Request | FrameKind::Notification => {
+                            // Forward to handler
+                            let _ = incoming_tx.send((frame.id, frame.payload)).await;
+                        }
+                    }
+                }
+
+                consumed += 4 + frame_len;
+            }
+
+            // Shift remaining data to front
+            if consumed > 0 {
+                buf.copy_within(consumed..filled, 0);
+                filled -= consumed;
+            }
+        }
+    });
+
+    Ok((conn, incoming_rx))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::duplex;
+
+    #[tokio::test]
+    async fn test_socket_transport() {
+        // Create a bidirectional pipe
+        let (client_stream, server_stream) = duplex(64 * 1024);
+        let (client_read, client_write) = tokio::io::split(client_stream);
+        let (server_read, server_write) = tokio::io::split(server_stream);
+
+        // Set up client side
+        let (client_conn, _client_incoming) = run(client_read, client_write).await.unwrap();
+
+        // Set up server side
+        let (server_conn, mut server_incoming) = run(server_read, server_write).await.unwrap();
+
+        // Spawn server handler
+        let server_conn_clone = server_conn.clone();
+        tokio::spawn(async move {
+            while let Some((id, payload)) = server_incoming.recv().await {
+                // Echo back with prefix
+                let mut response = b"echo: ".to_vec();
+                response.extend_from_slice(&payload);
+                let _ = server_conn_clone.respond(id, response).await;
+            }
+        });
+
+        // Client sends request
+        let response = client_conn.request(b"hello".to_vec()).await.unwrap();
+        assert_eq!(response, b"echo: hello");
+
+        // Multiple requests
+        let r1 = client_conn.request(b"one".to_vec());
+        let r2 = client_conn.request(b"two".to_vec());
+        let (resp1, resp2) = tokio::join!(r1, r2);
+        assert_eq!(resp1.unwrap(), b"echo: one");
+        assert_eq!(resp2.unwrap(), b"echo: two");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the `rapace` crate (RaPaCe = RPC) for bidirectional async RPC
- Supports communication over shared memory (SPSC ring buffers) for local plugins
- Supports socket transport (AsyncRead + AsyncWrite) for remote plugins
- Includes a `service!` macro for defining typed RPC interfaces with Facet serialization

## Features

- **Wire protocol**: Length-prefixed frames with request/response correlation via IDs
- **Bidirectional**: Both host and plugin can expose services and call each other
- **Shared memory transport**: Lock-free SPSC ring buffers via `shm_open`/`mmap`
- **Socket transport**: Works with any AsyncRead + AsyncWrite (TCP, Unix sockets, etc.)
- **Typed services**: `service!` macro generates request/response enums, client struct, and dispatch function

## Example

```rust
rapace::service! {
    pub trait TemplateService {
        async fn render(template_name: String) -> String;
    }
}
```

## Test plan

- [x] Unit tests pass (`cargo test --package rapace`)
- [x] Cross-process shm example works (`shm_host` + `shm_plugin`)
- [ ] CI passes

This lays the groundwork for extracting gingembre as a plugin (#129).