### PR TITLE
Fix test issues #168 and #170

### DIFF
--- a/browser-tests/tests/livereload.spec.ts
+++ b/browser-tests/tests/livereload.spec.ts
@@ -100,7 +100,16 @@ test.describe("Livereload and DOM Patching", () => {
   });
 
   test("page structure remains valid after DOM patch", async ({ page }) => {
+    // Capture console logs
+    page.on("console", (msg) => {
+      console.log(`[browser ${msg.type()}] ${msg.text()}`);
+    });
+
     await page.goto(site.url);
+
+    // Wait for devtools to connect (the connection status indicator)
+    // Give it a bit more time to establish the WebSocket connection
+    await page.waitForTimeout(2000);
 
     // Set marker
     await page.evaluate(() => {
@@ -161,6 +170,9 @@ test.describe("Livereload and DOM Patching", () => {
   test("multiple rapid edits result in correct final state", async ({ page }) => {
     await page.goto(site.url);
 
+    // Wait for devtools to connect
+    await page.waitForTimeout(2000);
+
     await page.evaluate(() => {
       (window as any).__testMarker = "rapid-edits";
     });
@@ -214,6 +226,9 @@ test.describe("DOM Patching Edge Cases", () => {
 
   test("adding new paragraph preserves existing content", async ({ page }) => {
     await page.goto(site.url);
+
+    // Wait for devtools to connect
+    await page.waitForTimeout(2000);
 
     await page.evaluate(() => {
       (window as any).__testMarker = "add-paragraph";

--- a/crates/integration-tests/src/tests/code_execution.rs
+++ b/crates/integration-tests/src/tests/code_execution.rs
@@ -11,7 +11,7 @@ title = "Home"
 
 # Home
 
-```rust
+```rust,test
 fn main() {
     println!("Hello from code execution!");
 }
@@ -38,7 +38,7 @@ title = "Home"
 
 # Colored Output
 
-```rust
+```rust,test
 fn main() {
     // Output with ANSI escape codes for colors
     println!("\x1b[32mGreen text\x1b[0m");
@@ -63,7 +63,7 @@ title = "Home"
 
 # Type Error
 
-```rust
+```rust,test
 fn main() {
     let x: i32 = "not a number";
     println!("{}", x);
@@ -95,7 +95,7 @@ title = "Home"
 
 # Compilation Error
 
-```rust
+```rust,test
 fn main() {
     let undefined_variable;
     println!("{}", undefined_variable);
@@ -125,7 +125,7 @@ title = "Home"
 
 The following code is supposed to work but has a typo:
 
-```rust
+```rust,test
 fn main() {
     // Intentional error - calling non-existent method
     let numbers = vec![1, 2, 3];
@@ -157,7 +157,7 @@ title = "Home"
 
 First sample:
 
-```rust
+```rust,test
 fn main() {
     println!("Sample 1");
 }
@@ -165,7 +165,7 @@ fn main() {
 
 Second sample:
 
-```rust
+```rust,test
 fn main() {
     println!("Sample 2");
 }
@@ -227,7 +227,7 @@ title = "Home"
 
 # Panic Test
 
-```rust
+```rust,test
 fn main() {
     panic!("Intentional panic for testing!");
 }


### PR DESCRIPTION
## Summary

Fixes two test-related issues:

### #170: Code execution integration tests use wrong syntax
- Added missing `,test` suffix to all rust code blocks in integration tests
- This matches the opt-in code execution behavior introduced earlier

### #168: Browser tests failing for structural DOM changes  
- Root cause was a race condition, not DOM patching
- Tests were modifying files before devtools WebSocket connection was established
- Added 2000ms wait for devtools connection in the 3 affected tests
- DOM patching was actually working correctly - patches just weren't being received

## Test Results
- All 8 code execution integration tests now pass
- All 12 browser tests now pass