### PR TITLE
Fix RustConfig KDL parsing for node+argument syntax

### DIFF
--- a/crates/dodeca-code-execution-types/src/lib.rs
+++ b/crates/dodeca-code-execution-types/src/lib.rs
@@ -9,8 +9,8 @@ use std::collections::HashMap;
 
 // Re-export config types from the config crate
 pub use dodeca_code_execution_config::{
-    CodeExecutionConfig as KdlCodeExecutionConfig, DependenciesConfig, DependencySpec, RustConfig,
-    default_rust_dependencies,
+    CodeExecutionConfig as KdlCodeExecutionConfig, DependenciesConfig, DependencySpec, MultiValue,
+    RustConfig, SingleValue, default_rust_dependencies,
 };
 
 /// Runtime configuration for code sample execution (used by the plugin)
@@ -75,26 +75,44 @@ impl CodeExecutionConfig {
             command: kdl
                 .rust
                 .command
-                .clone()
+                .as_ref()
+                .map(|c| c.value.clone())
                 .unwrap_or_else(|| "cargo".to_string()),
             args: kdl
                 .rust
                 .args
-                .clone()
+                .as_ref()
+                .map(|a| a.values.clone())
                 .unwrap_or_else(|| vec!["run".to_string(), "--release".to_string()]),
             extension: kdl
                 .rust
                 .extension
-                .clone()
+                .as_ref()
+                .map(|e| e.value.clone())
                 .unwrap_or_else(|| "rs".to_string()),
-            prepare_code: kdl.rust.prepare_code.unwrap_or(true),
-            auto_imports: kdl.rust.auto_imports.clone().unwrap_or_else(|| {
-                vec![
-                    "use std::collections::HashMap;".to_string(),
-                    "use facet::Facet;".to_string(),
-                ]
-            }),
-            show_output: kdl.rust.show_output.unwrap_or(true),
+            prepare_code: kdl
+                .rust
+                .prepare_code
+                .as_ref()
+                .map(|p| p.value)
+                .unwrap_or(true),
+            auto_imports: kdl
+                .rust
+                .auto_imports
+                .as_ref()
+                .map(|a| a.values.clone())
+                .unwrap_or_else(|| {
+                    vec![
+                        "use std::collections::HashMap;".to_string(),
+                        "use facet::Facet;".to_string(),
+                    ]
+                }),
+            show_output: kdl
+                .rust
+                .show_output
+                .as_ref()
+                .map(|s| s.value)
+                .unwrap_or(true),
             expected_compile_errors: vec![],
         };
         language_config.insert("rust".to_string(), rust_config);


### PR DESCRIPTION
## Summary

Fixes the KDL parsing error when loading rapace's `dodeca.kdl` config:

```
Error: Failed to parse .config/dodeca.kdl: type mismatch: expected scalar value, got StructStart(Element)
```

The issue was that `RustConfig` fields used `#[facet(kdl::property)]` which expects `key=value` syntax, but the actual config uses KDL node+argument syntax:

```kdl
rust {
    command "cargo"              // This is a node with argument, NOT command="cargo"
    args "run" "--quiet"         // Multiple arguments on a single node
}
```

## Changes

- Add `SingleValue<T>` wrapper for single-argument child nodes
- Add `MultiValue<T>` wrapper for multi-argument child nodes  
- Update `RustConfig` to use `kdl::child` with wrapper types
- Update runtime config conversion to unwrap the new types
- Add tests verifying the rapace config format parses correctly

## KDL Insight

In KDL, there's an important distinction:
- **Properties**: `key=value` (with equals sign)
- **Child nodes with arguments**: `node_name "arg1" "arg2"` (no equals sign)

The rapace config uses child nodes with arguments throughout, which requires wrapper types with `#[facet(kdl::arguments)]` to capture the positional values.

## Test plan
- [x] New tests pass for RustConfig parsing
- [x] Existing tests pass
- [x] Clippy passes
- [x] Doc tests pass