### PR TITLE
Update marq to include trailing newline fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2956,7 +2956,7 @@ checksum = "6738d2e996274e499bc7b0d693c858b7720b9cd2543a0643a3087e6cb0a4fa16"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3193,7 +3193,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3233,7 +3233,7 @@ dependencies = [
 [[package]]
 name = "facet"
 version = "0.42.0"
-source = "git+https://github.com/facet-rs/facet?branch=main#004895951de0847a2fc0fef50581dbc8a2bc2df4"
+source = "git+https://github.com/facet-rs/facet?branch=main#d1dda2eeff214c83294d14f0a400e972c67e8475"
 dependencies = [
  "autocfg",
  "facet-core",
@@ -3271,7 +3271,7 @@ dependencies = [
 [[package]]
 name = "facet-core"
 version = "0.42.0"
-source = "git+https://github.com/facet-rs/facet?branch=main#004895951de0847a2fc0fef50581dbc8a2bc2df4"
+source = "git+https://github.com/facet-rs/facet?branch=main#d1dda2eeff214c83294d14f0a400e972c67e8475"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3322,7 +3322,7 @@ dependencies = [
 [[package]]
 name = "facet-format"
 version = "0.42.0"
-source = "git+https://github.com/facet-rs/facet?branch=main#004895951de0847a2fc0fef50581dbc8a2bc2df4"
+source = "git+https://github.com/facet-rs/facet?branch=main#d1dda2eeff214c83294d14f0a400e972c67e8475"
 dependencies = [
  "cranelift",
  "cranelift-jit",
@@ -3390,7 +3390,7 @@ dependencies = [
 [[package]]
 name = "facet-macro-parse"
 version = "0.42.0"
-source = "git+https://github.com/facet-rs/facet?branch=main#004895951de0847a2fc0fef50581dbc8a2bc2df4"
+source = "git+https://github.com/facet-rs/facet?branch=main#d1dda2eeff214c83294d14f0a400e972c67e8475"
 dependencies = [
  "facet-macro-types",
  "proc-macro2",
@@ -3400,7 +3400,7 @@ dependencies = [
 [[package]]
 name = "facet-macro-types"
 version = "0.42.0"
-source = "git+https://github.com/facet-rs/facet?branch=main#004895951de0847a2fc0fef50581dbc8a2bc2df4"
+source = "git+https://github.com/facet-rs/facet?branch=main#d1dda2eeff214c83294d14f0a400e972c67e8475"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3410,7 +3410,7 @@ dependencies = [
 [[package]]
 name = "facet-macros"
 version = "0.42.0"
-source = "git+https://github.com/facet-rs/facet?branch=main#004895951de0847a2fc0fef50581dbc8a2bc2df4"
+source = "git+https://github.com/facet-rs/facet?branch=main#d1dda2eeff214c83294d14f0a400e972c67e8475"
 dependencies = [
  "facet-macros-impl",
 ]
@@ -3418,7 +3418,7 @@ dependencies = [
 [[package]]
 name = "facet-macros-impl"
 version = "0.42.0"
-source = "git+https://github.com/facet-rs/facet?branch=main#004895951de0847a2fc0fef50581dbc8a2bc2df4"
+source = "git+https://github.com/facet-rs/facet?branch=main#d1dda2eeff214c83294d14f0a400e972c67e8475"
 dependencies = [
  "facet-macro-parse",
  "facet-macro-types",
@@ -3431,7 +3431,7 @@ dependencies = [
 [[package]]
 name = "facet-path"
 version = "0.42.0"
-source = "git+https://github.com/facet-rs/facet?branch=main#004895951de0847a2fc0fef50581dbc8a2bc2df4"
+source = "git+https://github.com/facet-rs/facet?branch=main#d1dda2eeff214c83294d14f0a400e972c67e8475"
 dependencies = [
  "arborium",
  "facet-core",
@@ -3457,7 +3457,7 @@ dependencies = [
 [[package]]
 name = "facet-pretty"
 version = "0.42.0"
-source = "git+https://github.com/facet-rs/facet?branch=main#004895951de0847a2fc0fef50581dbc8a2bc2df4"
+source = "git+https://github.com/facet-rs/facet?branch=main#d1dda2eeff214c83294d14f0a400e972c67e8475"
 dependencies = [
  "facet-core",
  "facet-reflect",
@@ -3467,7 +3467,7 @@ dependencies = [
 [[package]]
 name = "facet-reflect"
 version = "0.42.0"
-source = "git+https://github.com/facet-rs/facet?branch=main#004895951de0847a2fc0fef50581dbc8a2bc2df4"
+source = "git+https://github.com/facet-rs/facet?branch=main#d1dda2eeff214c83294d14f0a400e972c67e8475"
 dependencies = [
  "facet-core",
  "miette",
@@ -3476,12 +3476,12 @@ dependencies = [
 [[package]]
 name = "facet-singularize"
 version = "0.42.0"
-source = "git+https://github.com/facet-rs/facet?branch=main#004895951de0847a2fc0fef50581dbc8a2bc2df4"
+source = "git+https://github.com/facet-rs/facet?branch=main#d1dda2eeff214c83294d14f0a400e972c67e8475"
 
 [[package]]
 name = "facet-solver"
 version = "0.42.0"
-source = "git+https://github.com/facet-rs/facet?branch=main#004895951de0847a2fc0fef50581dbc8a2bc2df4"
+source = "git+https://github.com/facet-rs/facet?branch=main#d1dda2eeff214c83294d14f0a400e972c67e8475"
 dependencies = [
  "facet-core",
  "facet-reflect",
@@ -3490,7 +3490,7 @@ dependencies = [
 [[package]]
 name = "facet-svg"
 version = "0.42.0"
-source = "git+https://github.com/facet-rs/facet?branch=main#004895951de0847a2fc0fef50581dbc8a2bc2df4"
+source = "git+https://github.com/facet-rs/facet?branch=main#d1dda2eeff214c83294d14f0a400e972c67e8475"
 dependencies = [
  "facet",
  "facet-format",
@@ -3500,7 +3500,7 @@ dependencies = [
 [[package]]
 name = "facet-toml"
 version = "0.42.0"
-source = "git+https://github.com/facet-rs/facet?branch=main#004895951de0847a2fc0fef50581dbc8a2bc2df4"
+source = "git+https://github.com/facet-rs/facet?branch=main#d1dda2eeff214c83294d14f0a400e972c67e8475"
 dependencies = [
  "facet-core",
  "facet-format",
@@ -3512,7 +3512,7 @@ dependencies = [
 [[package]]
 name = "facet-value"
 version = "0.42.0"
-source = "git+https://github.com/facet-rs/facet?branch=main#004895951de0847a2fc0fef50581dbc8a2bc2df4"
+source = "git+https://github.com/facet-rs/facet?branch=main#d1dda2eeff214c83294d14f0a400e972c67e8475"
 dependencies = [
  "facet-core",
  "facet-reflect",
@@ -3522,7 +3522,7 @@ dependencies = [
 [[package]]
 name = "facet-xml"
 version = "0.42.0"
-source = "git+https://github.com/facet-rs/facet?branch=main#004895951de0847a2fc0fef50581dbc8a2bc2df4"
+source = "git+https://github.com/facet-rs/facet?branch=main#d1dda2eeff214c83294d14f0a400e972c67e8475"
 dependencies = [
  "facet",
  "facet-core",
@@ -3534,7 +3534,7 @@ dependencies = [
 [[package]]
 name = "facet-yaml"
 version = "0.42.0"
-source = "git+https://github.com/facet-rs/facet?branch=main#004895951de0847a2fc0fef50581dbc8a2bc2df4"
+source = "git+https://github.com/facet-rs/facet?branch=main#d1dda2eeff214c83294d14f0a400e972c67e8475"
 dependencies = [
  "facet",
  "facet-core",
@@ -5313,7 +5313,7 @@ dependencies = [
 [[package]]
 name = "marq"
 version = "0.1.0"
-source = "git+https://github.com/bearcove/marq#9eff49b6e0fc7a461bd28d70d54b8b72b7a54e03"
+source = "git+https://github.com/bearcove/marq#8e722aab6ee1c34fe321ed637651f0a6c7afff6b"
 dependencies = [
  "aasvg",
  "arborium",
@@ -5645,7 +5645,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6958,7 +6958,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.1",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7605,7 +7605,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7662,7 +7662,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8472,7 +8472,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9541,7 +9541,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Updates marq to include the fix for trailing newlines in code blocks (bearcove/marq@8e722aa).

This completes the fix for extra whitespace appearing after syntax-highlighted code blocks.

## Test plan

- [x] Integration tests pass