### PR TITLE
Fix #211: Enable stdio for dialoguer cell and add tracing to init command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -151,7 +151,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1718,7 +1718,6 @@ dependencies = [
 name = "cell-markdown"
 version = "0.6.1"
 dependencies = [
- "cell-host-proto",
  "cell-markdown-proto",
  "dodeca-cell-runtime",
  "marq",
@@ -2595,7 +2594,7 @@ checksum = "6738d2e996274e499bc7b0d693c858b7720b9cd2543a0643a3087e6cb0a4fa16"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2852,7 +2851,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3259,7 +3258,7 @@ dependencies = [
 [[package]]
 name = "figue"
 version = "1.0.0"
-source = "git+https://github.com/bearcove/figue?branch=main#e20a2f8cb43e316c95ca6c849a35d6aabc7b0a5a"
+source = "git+https://github.com/bearcove/figue?branch=main#128fdc7abc0d9828883dfe33afb3e97c34925fa5"
 dependencies = [
  "ariadne 0.6.0",
  "camino",
@@ -3283,7 +3282,7 @@ dependencies = [
 [[package]]
 name = "figue-attrs"
 version = "1.0.0"
-source = "git+https://github.com/bearcove/figue?branch=main#e20a2f8cb43e316c95ca6c849a35d6aabc7b0a5a"
+source = "git+https://github.com/bearcove/figue?branch=main#128fdc7abc0d9828883dfe33afb3e97c34925fa5"
 dependencies = [
  "facet",
 ]
@@ -4496,7 +4495,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5192,7 +5191,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5938,9 +5937,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.5"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9eb05c21a464ea704b53158d358a31e6425db2f63a1a7312268b05fe2b75f7"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -5948,9 +5947,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.5"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f9dbced329c441fa79d80472764b1a2c7e57123553b8519b36663a2fb234ed"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
 dependencies = [
  "pest",
  "pest_generator",
@@ -5958,9 +5957,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.5"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bb96d5051a78f44f43c8f712d8e810adb0ebf923fc9ed2655a7f66f63ba8ee5"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
 dependencies = [
  "pest",
  "pest_meta",
@@ -5971,9 +5970,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.5"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602113b5b5e8621770cfd490cfd90b9f84ab29bd2b0e49ad83eb6d186cef2365"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
  "sha2",
@@ -7124,7 +7123,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7181,7 +7180,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8064,7 +8063,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8265,9 +8264,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.46"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "libc",
@@ -8752,9 +8751,9 @@ dependencies = [
 
 [[package]]
 name = "ureq"
-version = "3.1.4"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39cb1dbab692d82a977c0392ffac19e188bd9186a9f32806f0aaa859d75585a"
+checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
 dependencies = [
  "base64",
  "log",
@@ -9167,7 +9166,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/cells/cell-markdown/Cargo.toml
+++ b/cells/cell-markdown/Cargo.toml
@@ -13,7 +13,6 @@ name = "ddc-cell-markdown"
 path = "src/main.rs"
 
 [dependencies]
-cell-host-proto = { path = "../cell-host-proto" }
 cell-markdown-proto = { path = "../cell-markdown-proto" }
 dodeca-cell-runtime = { path = "../../crates/dodeca-cell-runtime" }
 marq = { git = "https://github.com/bearcove/marq", features = [

--- a/crates/dodeca/src/cells.rs
+++ b/crates/dodeca/src/cells.rs
@@ -48,7 +48,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, OnceLock};
 use std::time::SystemTime;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, warn};
 
 use crate::serve::SiteServer;
 
@@ -510,7 +510,7 @@ const CELL_DEFS: &[CellDef] = &[
     CellDef::new("fonts"),
     CellDef::new("linkcheck"),
     CellDef::new("html-diff"),
-    CellDef::new("dialoguer"),
+    CellDef::new("dialoguer").inherit_stdio(),
     CellDef::new("code-execution"),
     CellDef::new("http"),
     CellDef::new("gingembre"),
@@ -545,7 +545,7 @@ impl CellRegistry {
 async fn init_cells() -> CellRegistry {
     match init_cells_inner().await {
         Ok(()) => {
-            info!("Cell infrastructure initialized");
+            debug!("Cell infrastructure initialized");
         }
         Err(e) => {
             let _ = INIT_ERROR.set(e.to_string());
@@ -593,7 +593,7 @@ async fn init_cells_inner() -> eyre::Result<()> {
     let max_guests: u32 = env_or("DODECA_SHM_MAX_GUESTS", 24);
     let ring_size: u32 = env_or("DODECA_SHM_RING_SIZE", 128);
 
-    info!(
+    debug!(
         slots_per_guest,
         max_guests, ring_size, max_payload_mb, "SHM config (override with DODECA_SHM_* env vars)"
     );
@@ -718,7 +718,7 @@ async fn init_cells_inner() -> eyre::Result<()> {
 
     // Spawn driver task
     let driver_handle = crate::spawn::spawn(async move {
-        info!("MultiPeerHostDriver: starting (lazy spawning mode)");
+        debug!("MultiPeerHostDriver: starting (lazy spawning mode)");
         debug!("[driver task] before driver.run()");
 
         let result = driver.run().await;

--- a/crates/dodeca/src/main.rs
+++ b/crates/dodeca/src/main.rs
@@ -508,7 +508,12 @@ async fn async_main(command: Command) -> Result<()> {
             )
             .await
         }
-        Command::Init(args) => init::run_init(args.name, args.template).await,
+        Command::Init(args) => {
+            // Initialize tracing early so errors are visible
+            logging::init_standard_tracing();
+
+            init::run_init(args.name, args.template).await
+        }
         Command::Term(args) => run_term(args).await,
     }
 }


### PR DESCRIPTION
Fixes #211

The `ddc init` command was immediately failing with "Cancelled" when no template was specified because the dialoguer cell couldn't interact with the terminal.

## Changes

- Add `inherit_stdio()` to dialoguer cell so it can read from stdin and write to stdout for interactive prompts
- Initialize tracing for init command to make errors visible during debugging
- Change cell infrastructure logs from INFO to DEBUG level (less noise for simple commands)

The dialoguer cell needs access to stdio just like the term and tui cells, since it needs to show interactive prompts to the user.