### PR TITLE
Upgrade to roam protocol v4 (drop COBS framing)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
  "x11rb",
 ]
 
@@ -1187,7 +1187,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "regex",
@@ -1998,16 +1998,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cobs"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ef0193218d365c251b5b9297f9911a908a8ddd2ebd3a36cc5d0ef0f63aee9e"
-dependencies = [
- "heapless 0.9.2",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "codemap"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2594,7 +2584,7 @@ checksum = "6738d2e996274e499bc7b0d693c858b7720b9cd2543a0643a3087e6cb0a4fa16"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2851,7 +2841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2918,7 +2908,7 @@ dependencies = [
 [[package]]
 name = "facet"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#101b655c94e1926f67d5c36fc2b06d161a6c4488"
+source = "git+https://github.com/facet-rs/facet?branch=main#faf758710befff626837a1e25eaccb5594e11fb7"
 dependencies = [
  "autocfg",
  "facet-core",
@@ -2929,7 +2919,7 @@ dependencies = [
 [[package]]
 name = "facet-cargo-toml"
 version = "0.43.0"
-source = "git+https://github.com/bearcove/facet-cargo-toml?branch=main#9bf8c527cf5d3b8a4165367aefd523b449eddab7"
+source = "git+https://github.com/bearcove/facet-cargo-toml?branch=main#c4dd2db9d7f9401f522db76f876bf6775074f8e0"
 dependencies = [
  "camino",
  "facet",
@@ -2943,7 +2933,7 @@ dependencies = [
 [[package]]
 name = "facet-core"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#101b655c94e1926f67d5c36fc2b06d161a6c4488"
+source = "git+https://github.com/facet-rs/facet?branch=main#faf758710befff626837a1e25eaccb5594e11fb7"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2968,7 +2958,7 @@ dependencies = [
 [[package]]
 name = "facet-dessert"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#101b655c94e1926f67d5c36fc2b06d161a6c4488"
+source = "git+https://github.com/facet-rs/facet?branch=main#faf758710befff626837a1e25eaccb5594e11fb7"
 dependencies = [
  "facet-core",
  "facet-reflect",
@@ -2990,7 +2980,7 @@ dependencies = [
 [[package]]
 name = "facet-error"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#101b655c94e1926f67d5c36fc2b06d161a6c4488"
+source = "git+https://github.com/facet-rs/facet?branch=main#faf758710befff626837a1e25eaccb5594e11fb7"
 dependencies = [
  "facet",
 ]
@@ -2998,7 +2988,7 @@ dependencies = [
 [[package]]
 name = "facet-format"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#101b655c94e1926f67d5c36fc2b06d161a6c4488"
+source = "git+https://github.com/facet-rs/facet?branch=main#faf758710befff626837a1e25eaccb5594e11fb7"
 dependencies = [
  "facet-core",
  "facet-dessert",
@@ -3022,7 +3012,7 @@ dependencies = [
 [[package]]
 name = "facet-macro-parse"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#101b655c94e1926f67d5c36fc2b06d161a6c4488"
+source = "git+https://github.com/facet-rs/facet?branch=main#faf758710befff626837a1e25eaccb5594e11fb7"
 dependencies = [
  "facet-macro-types",
  "proc-macro2",
@@ -3032,7 +3022,7 @@ dependencies = [
 [[package]]
 name = "facet-macro-types"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#101b655c94e1926f67d5c36fc2b06d161a6c4488"
+source = "git+https://github.com/facet-rs/facet?branch=main#faf758710befff626837a1e25eaccb5594e11fb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3042,7 +3032,7 @@ dependencies = [
 [[package]]
 name = "facet-macros"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#101b655c94e1926f67d5c36fc2b06d161a6c4488"
+source = "git+https://github.com/facet-rs/facet?branch=main#faf758710befff626837a1e25eaccb5594e11fb7"
 dependencies = [
  "facet-macros-impl",
 ]
@@ -3050,7 +3040,7 @@ dependencies = [
 [[package]]
 name = "facet-macros-impl"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#101b655c94e1926f67d5c36fc2b06d161a6c4488"
+source = "git+https://github.com/facet-rs/facet?branch=main#faf758710befff626837a1e25eaccb5594e11fb7"
 dependencies = [
  "facet-macro-parse",
  "facet-macro-types",
@@ -3063,7 +3053,7 @@ dependencies = [
 [[package]]
 name = "facet-path"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#101b655c94e1926f67d5c36fc2b06d161a6c4488"
+source = "git+https://github.com/facet-rs/facet?branch=main#faf758710befff626837a1e25eaccb5594e11fb7"
 dependencies = [
  "facet-core",
 ]
@@ -3071,7 +3061,7 @@ dependencies = [
 [[package]]
 name = "facet-postcard"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#101b655c94e1926f67d5c36fc2b06d161a6c4488"
+source = "git+https://github.com/facet-rs/facet?branch=main#faf758710befff626837a1e25eaccb5594e11fb7"
 dependencies = [
  "camino",
  "facet-core",
@@ -3085,7 +3075,7 @@ dependencies = [
 [[package]]
 name = "facet-pretty"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#101b655c94e1926f67d5c36fc2b06d161a6c4488"
+source = "git+https://github.com/facet-rs/facet?branch=main#faf758710befff626837a1e25eaccb5594e11fb7"
 dependencies = [
  "facet-core",
  "facet-reflect",
@@ -3095,7 +3085,7 @@ dependencies = [
 [[package]]
 name = "facet-reflect"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#101b655c94e1926f67d5c36fc2b06d161a6c4488"
+source = "git+https://github.com/facet-rs/facet?branch=main#faf758710befff626837a1e25eaccb5594e11fb7"
 dependencies = [
  "facet-core",
  "facet-path",
@@ -3112,7 +3102,7 @@ source = "git+https://github.com/facet-rs/facet-xml?branch=main#a10a535c67269d86
 [[package]]
 name = "facet-solver"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#101b655c94e1926f67d5c36fc2b06d161a6c4488"
+source = "git+https://github.com/facet-rs/facet?branch=main#faf758710befff626837a1e25eaccb5594e11fb7"
 dependencies = [
  "facet-core",
  "facet-reflect",
@@ -3167,7 +3157,7 @@ dependencies = [
 [[package]]
 name = "facet-toml"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#101b655c94e1926f67d5c36fc2b06d161a6c4488"
+source = "git+https://github.com/facet-rs/facet?branch=main#faf758710befff626837a1e25eaccb5594e11fb7"
 dependencies = [
  "facet-core",
  "facet-format",
@@ -3178,7 +3168,7 @@ dependencies = [
 [[package]]
 name = "facet-value"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#101b655c94e1926f67d5c36fc2b06d161a6c4488"
+source = "git+https://github.com/facet-rs/facet?branch=main#faf758710befff626837a1e25eaccb5594e11fb7"
 dependencies = [
  "facet-core",
  "facet-format",
@@ -3813,15 +3803,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hash32"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3878,20 +3859,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
 dependencies = [
  "atomic-polyfill",
- "hash32 0.2.1",
+ "hash32",
  "rustc_version",
  "serde",
  "spin",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "heapless"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af2455f757db2b292a9b1768c4b70186d443bcb3b316252d6b540aec1cd89ed"
-dependencies = [
- "hash32 0.3.1",
  "stable_deref_trait",
 ]
 
@@ -4495,7 +4466,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4525,15 +4496,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -6215,10 +6177,10 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
 dependencies = [
- "cobs 0.3.0",
+ "cobs",
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
- "heapless 0.7.17",
+ "heapless",
  "serde",
 ]
 
@@ -6438,7 +6400,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6859,7 +6821,7 @@ dependencies = [
 [[package]]
 name = "roam"
 version = "3.0.0"
-source = "git+https://github.com/bearcove/roam?branch=main#24348b351f5e91543963a96967c193b0f2e852d4"
+source = "git+https://github.com/bearcove/roam?branch=main#96ee3d4bc0775b6489475c58628ae3f0f7f7db20"
 dependencies = [
  "facet",
  "facet-core",
@@ -6876,7 +6838,7 @@ dependencies = [
 [[package]]
 name = "roam-fdpass"
 version = "3.0.0"
-source = "git+https://github.com/bearcove/roam?branch=main#24348b351f5e91543963a96967c193b0f2e852d4"
+source = "git+https://github.com/bearcove/roam?branch=main#96ee3d4bc0775b6489475c58628ae3f0f7f7db20"
 dependencies = [
  "libc",
  "passfd",
@@ -6887,7 +6849,7 @@ dependencies = [
 [[package]]
 name = "roam-frame"
 version = "3.0.0"
-source = "git+https://github.com/bearcove/roam?branch=main#24348b351f5e91543963a96967c193b0f2e852d4"
+source = "git+https://github.com/bearcove/roam?branch=main#96ee3d4bc0775b6489475c58628ae3f0f7f7db20"
 dependencies = [
  "bytes",
  "facet",
@@ -6897,7 +6859,7 @@ dependencies = [
 [[package]]
 name = "roam-hash"
 version = "3.0.0"
-source = "git+https://github.com/bearcove/roam?branch=main#24348b351f5e91543963a96967c193b0f2e852d4"
+source = "git+https://github.com/bearcove/roam?branch=main#96ee3d4bc0775b6489475c58628ae3f0f7f7db20"
 dependencies = [
  "blake3",
  "facet-core",
@@ -6908,7 +6870,7 @@ dependencies = [
 [[package]]
 name = "roam-local"
 version = "3.0.0"
-source = "git+https://github.com/bearcove/roam?branch=main#24348b351f5e91543963a96967c193b0f2e852d4"
+source = "git+https://github.com/bearcove/roam?branch=main#96ee3d4bc0775b6489475c58628ae3f0f7f7db20"
 dependencies = [
  "tokio",
 ]
@@ -6916,7 +6878,7 @@ dependencies = [
 [[package]]
 name = "roam-macros-parse"
 version = "3.0.0"
-source = "git+https://github.com/bearcove/roam?branch=main#24348b351f5e91543963a96967c193b0f2e852d4"
+source = "git+https://github.com/bearcove/roam?branch=main#96ee3d4bc0775b6489475c58628ae3f0f7f7db20"
 dependencies = [
  "proc-macro2",
  "unsynn",
@@ -6925,7 +6887,7 @@ dependencies = [
 [[package]]
 name = "roam-schema"
 version = "3.0.0"
-source = "git+https://github.com/bearcove/roam?branch=main#24348b351f5e91543963a96967c193b0f2e852d4"
+source = "git+https://github.com/bearcove/roam?branch=main#96ee3d4bc0775b6489475c58628ae3f0f7f7db20"
 dependencies = [
  "facet",
  "facet-core",
@@ -6935,7 +6897,7 @@ dependencies = [
 [[package]]
 name = "roam-service-macros"
 version = "3.0.0"
-source = "git+https://github.com/bearcove/roam?branch=main#24348b351f5e91543963a96967c193b0f2e852d4"
+source = "git+https://github.com/bearcove/roam?branch=main#96ee3d4bc0775b6489475c58628ae3f0f7f7db20"
 dependencies = [
  "facet-cargo-toml",
  "heck",
@@ -6947,7 +6909,7 @@ dependencies = [
 [[package]]
 name = "roam-session"
 version = "3.0.0"
-source = "git+https://github.com/bearcove/roam?branch=main#24348b351f5e91543963a96967c193b0f2e852d4"
+source = "git+https://github.com/bearcove/roam?branch=main#96ee3d4bc0775b6489475c58628ae3f0f7f7db20"
 dependencies = [
  "async-channel",
  "facet",
@@ -6970,7 +6932,7 @@ dependencies = [
 [[package]]
 name = "roam-shm"
 version = "3.0.0"
-source = "git+https://github.com/bearcove/roam?branch=main#24348b351f5e91543963a96967c193b0f2e852d4"
+source = "git+https://github.com/bearcove/roam?branch=main#96ee3d4bc0775b6489475c58628ae3f0f7f7db20"
 dependencies = [
  "facet",
  "facet-postcard",
@@ -6990,9 +6952,8 @@ dependencies = [
 [[package]]
 name = "roam-stream"
 version = "3.0.0"
-source = "git+https://github.com/bearcove/roam?branch=main#24348b351f5e91543963a96967c193b0f2e852d4"
+source = "git+https://github.com/bearcove/roam?branch=main#96ee3d4bc0775b6489475c58628ae3f0f7f7db20"
 dependencies = [
- "cobs 0.5.0",
  "facet",
  "facet-postcard",
  "roam-session",
@@ -7003,7 +6964,7 @@ dependencies = [
 [[package]]
 name = "roam-task-local"
 version = "3.0.0"
-source = "git+https://github.com/bearcove/roam?branch=main#24348b351f5e91543963a96967c193b0f2e852d4"
+source = "git+https://github.com/bearcove/roam?branch=main#96ee3d4bc0775b6489475c58628ae3f0f7f7db20"
 dependencies = [
  "pin-project-lite",
 ]
@@ -7011,7 +6972,7 @@ dependencies = [
 [[package]]
 name = "roam-tracing"
 version = "3.0.0"
-source = "git+https://github.com/bearcove/roam?branch=main#24348b351f5e91543963a96967c193b0f2e852d4"
+source = "git+https://github.com/bearcove/roam?branch=main#96ee3d4bc0775b6489475c58628ae3f0f7f7db20"
 dependencies = [
  "facet",
  "roam",
@@ -7024,7 +6985,7 @@ dependencies = [
 [[package]]
 name = "roam-websocket"
 version = "3.0.0"
-source = "git+https://github.com/bearcove/roam?branch=main#24348b351f5e91543963a96967c193b0f2e852d4"
+source = "git+https://github.com/bearcove/roam?branch=main#96ee3d4bc0775b6489475c58628ae3f0f7f7db20"
 dependencies = [
  "facet-postcard",
  "futures-channel",
@@ -7042,9 +7003,8 @@ dependencies = [
 [[package]]
 name = "roam-wire"
 version = "3.0.0"
-source = "git+https://github.com/bearcove/roam?branch=main#24348b351f5e91543963a96967c193b0f2e852d4"
+source = "git+https://github.com/bearcove/roam?branch=main#96ee3d4bc0775b6489475c58628ae3f0f7f7db20"
 dependencies = [
- "cobs 0.5.0",
  "facet",
  "facet-postcard",
 ]
@@ -7123,7 +7083,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7180,7 +7140,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7511,7 +7471,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 [[package]]
 name = "shm-primitives"
 version = "3.0.0"
-source = "git+https://github.com/bearcove/roam?branch=main#24348b351f5e91543963a96967c193b0f2e852d4"
+source = "git+https://github.com/bearcove/roam?branch=main#96ee3d4bc0775b6489475c58628ae3f0f7f7db20"
 dependencies = [
  "libc",
  "loom",
@@ -8063,7 +8023,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8742,7 +8702,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 [[package]]
 name = "ur-taking-me-with-you"
 version = "3.0.0"
-source = "git+https://github.com/bearcove/roam?branch=main#24348b351f5e91543963a96967c193b0f2e852d4"
+source = "git+https://github.com/bearcove/roam?branch=main#96ee3d4bc0775b6489475c58628ae3f0f7f7db20"
 dependencies = [
  "libc",
  "tokio",
@@ -9166,7 +9126,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Updates roam git dependencies to pick up protocol v4, which removes the legacy COBS framing layer from `roam-stream` and `roam-wire`. Also picks up latest facet (`faf7587`) and facet-cargo-toml (`c4dd2db`).

## Changes

- Updated all roam crates from `24348b3` to `96ee3d4`
- Updated all facet crates from `101b655` to `faf7587`
- Updated facet-cargo-toml from `9bf8c52` to `c4dd2db`
- Removed standalone `cobs 0.5.0` package (no longer needed by roam)

## Testing

- Pre-commit hooks passed (format, lint, tests)
- TypeScript and WASM components (mentioned in #231) may need separate updates if they depend on roam wire protocol directly

Fixes #231