### PR TITLE
Fix Vite CSS injection and Sass/node_modules handling

### DIFF
--- a/cells/cell-html/src/main.rs
+++ b/cells/cell-html/src/main.rs
@@ -1242,33 +1242,6 @@ fn extract_imports_from_js(
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn injects_vite_css_for_built_script_paths() {
-        let html = r#"
-            <html>
-              <head></head>
-              <body><script src="/assets/main-AbCdEf.js"></script></body>
-            </html>
-        "#;
-        let mut map = HashMap::new();
-        map.insert(
-            "/assets/main-AbCdEf.js".to_string(),
-            vec!["/assets/main-XyZ.css".to_string()],
-        );
-
-        let tendril = StrTendril::from(html);
-        let mut doc = hotmeal::parse(&tendril);
-        inject_vite_css_in_doc(&mut doc, &map);
-        let output = doc.to_html();
-
-        assert!(output.contains(r#"href="/assets/main-XyZ.css""#));
-    }
-}
-
 // ============================================================================
 // Code Button Injection
 // ============================================================================
@@ -1507,4 +1480,31 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let processor = HtmlProcessorImpl::new(handle);
         HtmlProcessorDispatcher::new(processor)
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn injects_vite_css_for_built_script_paths() {
+        let html = r#"
+            <html>
+              <head></head>
+              <body><script src="/assets/main-AbCdEf.js"></script></body>
+            </html>
+        "#;
+        let mut map = HashMap::new();
+        map.insert(
+            "/assets/main-AbCdEf.js".to_string(),
+            vec!["/assets/main-XyZ.css".to_string()],
+        );
+
+        let tendril = StrTendril::from(html);
+        let mut doc = hotmeal::parse(&tendril);
+        inject_vite_css_in_doc(&mut doc, &map);
+        let output = doc.to_html();
+
+        assert!(output.contains(r#"href="/assets/main-XyZ.css""#));
+    }
 }

--- a/cells/cell-html/src/main.rs
+++ b/cells/cell-html/src/main.rs
@@ -1242,6 +1242,33 @@ fn extract_imports_from_js(
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn injects_vite_css_for_built_script_paths() {
+        let html = r#"
+            <html>
+              <head></head>
+              <body><script src="/assets/main-AbCdEf.js"></script></body>
+            </html>
+        "#;
+        let mut map = HashMap::new();
+        map.insert(
+            "/assets/main-AbCdEf.js".to_string(),
+            vec!["/assets/main-XyZ.css".to_string()],
+        );
+
+        let tendril = StrTendril::from(html);
+        let mut doc = hotmeal::parse(&tendril);
+        inject_vite_css_in_doc(&mut doc, &map);
+        let output = doc.to_html();
+
+        assert!(output.contains(r#"href="/assets/main-XyZ.css""#));
+    }
+}
+
 // ============================================================================
 // Code Button Injection
 // ============================================================================

--- a/cells/cell-sass-proto/src/lib.rs
+++ b/cells/cell-sass-proto/src/lib.rs
@@ -19,6 +19,9 @@ pub enum SassResult {
 #[derive(Debug, Clone, Facet)]
 pub struct SassInput {
     pub files: HashMap<String, String>,
+    /// Additional filesystem load paths (for `@use` / `@import` resolution).
+    #[facet(default)]
+    pub load_paths: Vec<String>,
 }
 
 /// SASS compilation service implemented by the cell.

--- a/crates/dodeca/src/build_steps.rs
+++ b/crates/dodeca/src/build_steps.rs
@@ -33,7 +33,6 @@ pub enum BuildStepResult {
     Error(String),
 }
 
-
 /// Executor for build steps with caching.
 pub struct BuildStepExecutor {
     /// Build step definitions from config
@@ -46,10 +45,7 @@ pub struct BuildStepExecutor {
 
 impl BuildStepExecutor {
     /// Create a new executor with build step definitions.
-    pub fn new(
-        steps: Option<HashMap<String, BuildStepDef>>,
-        project_root: Utf8PathBuf,
-    ) -> Self {
+    pub fn new(steps: Option<HashMap<String, BuildStepDef>>, project_root: Utf8PathBuf) -> Self {
         let steps = steps.unwrap_or_default();
         tracing::debug!(num_steps = steps.len(), steps = ?steps.keys().collect::<Vec<_>>(), "BuildStepExecutor initialized");
         Self {
@@ -123,10 +119,8 @@ impl BuildStepExecutor {
         step_def: &BuildStepDef,
         params: &HashMap<String, String>,
     ) -> Result<CacheKey, String> {
-        let mut sorted_params: Vec<(String, String)> = params
-            .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect();
+        let mut sorted_params: Vec<(String, String)> =
+            params.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
         sorted_params.sort_by(|a, b| a.0.cmp(&b.0));
 
         // Hash file-typed parameters
@@ -179,10 +173,7 @@ impl BuildStepExecutor {
         params: &HashMap<String, String>,
     ) -> BuildStepResult {
         if cmd_args.is_empty() {
-            return BuildStepResult::Error(format!(
-                "Build step '{}' has empty command",
-                step_name
-            ));
+            return BuildStepResult::Error(format!("Build step '{}' has empty command", step_name));
         }
 
         // Interpolate parameters into command arguments
@@ -212,10 +203,7 @@ impl BuildStepExecutor {
         {
             Ok(output) => output,
             Err(e) => {
-                return BuildStepResult::Error(format!(
-                    "Failed to execute '{}': {}",
-                    program, e
-                ));
+                return BuildStepResult::Error(format!("Failed to execute '{}': {}", program, e));
             }
         };
 
@@ -263,10 +251,7 @@ impl BuildStepExecutor {
         let full_path = self.project_root.join(file_path);
         match tokio::fs::read(&full_path).await {
             Ok(contents) => BuildStepResult::Success(contents),
-            Err(e) => BuildStepResult::Error(format!(
-                "Failed to read file '{}': {}",
-                full_path, e
-            )),
+            Err(e) => BuildStepResult::Error(format!("Failed to read file '{}': {}", full_path, e)),
         }
     }
 }
@@ -307,10 +292,7 @@ mod tests {
         params.insert("file".to_string(), "test.txt".to_string());
         params.insert("width".to_string(), "100".to_string());
 
-        assert_eq!(
-            interpolate_params("{file}", &params),
-            "test.txt"
-        );
+        assert_eq!(interpolate_params("{file}", &params), "test.txt");
         assert_eq!(
             interpolate_params("convert {file} -resize {width}x", &params),
             "convert test.txt -resize 100x"

--- a/crates/dodeca/src/cells.rs
+++ b/crates/dodeca/src/cells.rs
@@ -1347,12 +1347,16 @@ pub async fn encode_jxl_cell(
 }
 
 // SASS/CSS cell wrappers
-pub async fn compile_sass_cell(input: &HashMap<String, String>) -> Result<SassResult, eyre::Error> {
+pub async fn compile_sass_cell(
+    input: &HashMap<String, String>,
+    load_paths: &[String],
+) -> Result<SassResult, eyre::Error> {
     let client = sass_cell()
         .await
         .ok_or_else(|| eyre::eyre!("SASS cell not available"))?;
     let sass_input = SassInput {
         files: input.clone(),
+        load_paths: load_paths.to_vec(),
     };
     client
         .compile_sass(sass_input)

--- a/crates/dodeca/src/logging.rs
+++ b/crates/dodeca/src/logging.rs
@@ -400,7 +400,8 @@ impl tracing::field::Visit for MessageVisitor {
         if field.name() == "message" {
             self.message = Some(value.to_string());
         } else {
-            self.fields.push((field.name().to_string(), value.to_string()));
+            self.fields
+                .push((field.name().to_string(), value.to_string()));
         }
     }
 
@@ -408,20 +409,24 @@ impl tracing::field::Visit for MessageVisitor {
         if field.name() == "message" {
             self.message = Some(format!("{value:?}"));
         } else {
-            self.fields.push((field.name().to_string(), format!("{value:?}")));
+            self.fields
+                .push((field.name().to_string(), format!("{value:?}")));
         }
     }
 
     fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
-        self.fields.push((field.name().to_string(), value.to_string()));
+        self.fields
+            .push((field.name().to_string(), value.to_string()));
     }
 
     fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
-        self.fields.push((field.name().to_string(), value.to_string()));
+        self.fields
+            .push((field.name().to_string(), value.to_string()));
     }
 
     fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
-        self.fields.push((field.name().to_string(), value.to_string()));
+        self.fields
+            .push((field.name().to_string(), value.to_string()));
     }
 }
 

--- a/crates/dodeca/src/main.rs
+++ b/crates/dodeca/src/main.rs
@@ -858,7 +858,11 @@ impl BuildContext {
             let static_files: Vec<Utf8PathBuf> = WalkBuilder::new(&static_dir)
                 .build()
                 .filter_map(|e| e.ok())
-                .filter(|e| e.file_type().map(|ft| ft.is_file()).unwrap_or(false))
+                .filter(|e| {
+                    e.file_type()
+                        .map(|ft| ft.is_file() || ft.is_symlink())
+                        .unwrap_or(false)
+                })
                 .filter_map(|e| Utf8PathBuf::from_path_buf(e.into_path()).ok())
                 .collect();
 
@@ -880,7 +884,11 @@ impl BuildContext {
             let dist_files: Vec<Utf8PathBuf> = WalkBuilder::new(&dist_dir)
                 .build()
                 .filter_map(|e| e.ok())
-                .filter(|e| e.file_type().map(|ft| ft.is_file()).unwrap_or(false))
+                .filter(|e| {
+                    e.file_type()
+                        .map(|ft| ft.is_file() || ft.is_symlink())
+                        .unwrap_or(false)
+                })
                 .filter_map(|e| Utf8PathBuf::from_path_buf(e.into_path()).ok())
                 .collect();
 

--- a/crates/gingembre/src/parser.rs
+++ b/crates/gingembre/src/parser.rs
@@ -623,9 +623,8 @@ impl Parser {
                 // Found a tag open — check if the keyword is "endcall"
                 let after_open = &source[pos + 2..];
                 let trimmed = after_open.trim_start();
-                if trimmed.starts_with("endcall") {
+                if let Some(rest) = trimmed.strip_prefix("endcall") {
                     // Verify it's the full keyword (not "endcallx")
-                    let rest = &trimmed["endcall".len()..];
                     if rest.is_empty()
                         || rest.starts_with(char::is_whitespace)
                         || rest.starts_with("%}")

--- a/crates/integration-tests/src/harness.rs
+++ b/crates/integration-tests/src/harness.rs
@@ -1077,7 +1077,9 @@ impl Response {
     pub fn img_src(&self, pattern: &str) -> Option<String> {
         let tendril = StrTendril::from(self.body.as_str());
         let doc = hotmeal::parse(&tendril);
-        find_attr_in_node(&doc, doc.root, "img", "src", &|value| matches_glob(pattern, value))
+        find_attr_in_node(&doc, doc.root, "img", "src", &|value| {
+            matches_glob(pattern, value)
+        })
     }
 
     /// Find a <link> tag's href attribute matching a glob pattern
@@ -1085,7 +1087,9 @@ impl Response {
     pub fn css_link(&self, pattern: &str) -> Option<String> {
         let tendril = StrTendril::from(self.body.as_str());
         let doc = hotmeal::parse(&tendril);
-        find_attr_in_node(&doc, doc.root, "link", "href", &|value| matches_glob(pattern, value))
+        find_attr_in_node(&doc, doc.root, "link", "href", &|value| {
+            matches_glob(pattern, value)
+        })
     }
 
     /// Extract a value using a regex with one capture group
@@ -1489,6 +1493,9 @@ mod unit_tests {
         assert!(matches_glob("*style*css", "/css/style.123.css"));
         assert!(matches_glob("*/style.*.css", "/css/style.123.css"));
         assert!(matches_glob("*/style.*.css", "/assets/css/style.123.css"));
-        assert!(!matches_glob("*/style.*.css", "/assets/css/style.123.css.map"));
+        assert!(!matches_glob(
+            "*/style.*.css",
+            "/assets/css/style.123.css.map"
+        ));
     }
 }

--- a/crates/integration-tests/src/main.rs
+++ b/crates/integration-tests/src/main.rs
@@ -537,6 +537,13 @@ fn collect_tests() -> Vec<Test> {
             func: static_assets::image_files_processed,
             ignored: false,
         },
+        #[cfg(unix)]
+        Test {
+            name: "symlinked_static_files_are_served",
+            module: "static_assets",
+            func: static_assets::symlinked_static_files_are_served,
+            ignored: false,
+        },
         // livereload tests
         Test {
             name: "test_new_section_detected",

--- a/crates/integration-tests/src/tests/build_steps.rs
+++ b/crates/integration-tests/src/tests/build_steps.rs
@@ -40,10 +40,7 @@ pub fn build_step_basic_command() {
     let site = TestSite::with_files(
         "sample-site",
         &[
-            (
-                ".config/dodeca.styx",
-                STYX_CONFIG,
-            ),
+            (".config/dodeca.styx", STYX_CONFIG),
             (
                 "templates/index.html",
                 r#"<!DOCTYPE html>
@@ -71,14 +68,8 @@ pub fn build_step_read_file() {
     let site = TestSite::with_files(
         "sample-site",
         &[
-            (
-                ".config/dodeca.styx",
-                STYX_CONFIG,
-            ),
-            (
-                "content/data.txt",
-                "Hello from data file!\n",
-            ),
+            (".config/dodeca.styx", STYX_CONFIG),
+            ("content/data.txt", "Hello from data file!\n"),
             (
                 "templates/index.html",
                 r#"<!DOCTYPE html>
@@ -105,14 +96,8 @@ pub fn build_step_command_with_file_param() {
     let site = TestSite::with_files(
         "sample-site",
         &[
-            (
-                ".config/dodeca.styx",
-                STYX_CONFIG,
-            ),
-            (
-                "content/words.txt",
-                "one two three four five\n",
-            ),
+            (".config/dodeca.styx", STYX_CONFIG),
+            ("content/words.txt", "one two three four five\n"),
             (
                 "templates/index.html",
                 r#"<!DOCTYPE html>
@@ -147,10 +132,7 @@ pub fn build_step_string_param() {
     let site = TestSite::with_files(
         "sample-site",
         &[
-            (
-                ".config/dodeca.styx",
-                STYX_CONFIG,
-            ),
+            (".config/dodeca.styx", STYX_CONFIG),
             (
                 "templates/index.html",
                 r#"<!DOCTYPE html>
@@ -177,10 +159,7 @@ pub fn build_step_caching_same_call() {
     let site = TestSite::with_files(
         "sample-site",
         &[
-            (
-                ".config/dodeca.styx",
-                STYX_CONFIG,
-            ),
+            (".config/dodeca.styx", STYX_CONFIG),
             (
                 "templates/index.html",
                 r#"<!DOCTYPE html>
@@ -234,18 +213,9 @@ pub fn build_step_caching_different_files() {
     let site = TestSite::with_files(
         "sample-site",
         &[
-            (
-                ".config/dodeca.styx",
-                STYX_CONFIG,
-            ),
-            (
-                "content/file1.txt",
-                "one two three\n",
-            ),
-            (
-                "content/file2.txt",
-                "alpha beta gamma delta epsilon\n",
-            ),
+            (".config/dodeca.styx", STYX_CONFIG),
+            ("content/file1.txt", "one two three\n"),
+            ("content/file2.txt", "alpha beta gamma delta epsilon\n"),
             (
                 "templates/index.html",
                 r#"<!DOCTYPE html>
@@ -280,14 +250,8 @@ pub fn build_step_cache_consistency() {
     let site = TestSite::with_files(
         "sample-site",
         &[
-            (
-                ".config/dodeca.styx",
-                STYX_CONFIG,
-            ),
-            (
-                "content/data.txt",
-                "stable content here\n",
-            ),
+            (".config/dodeca.styx", STYX_CONFIG),
+            ("content/data.txt", "stable content here\n"),
             (
                 "templates/index.html",
                 r#"<!DOCTYPE html>
@@ -324,14 +288,8 @@ pub fn builtin_read_function() {
     let site = TestSite::with_files(
         "sample-site",
         &[
-            (
-                ".config/dodeca.styx",
-                STYX_CONFIG,
-            ),
-            (
-                "content/readme.txt",
-                "This is readme content.\n",
-            ),
+            (".config/dodeca.styx", STYX_CONFIG),
+            ("content/readme.txt", "This is readme content.\n"),
             (
                 "templates/index.html",
                 r#"<!DOCTYPE html>
@@ -358,10 +316,7 @@ pub fn build_step_unknown_step_error() {
     let site = TestSite::with_files(
         "sample-site",
         &[
-            (
-                ".config/dodeca.styx",
-                STYX_CONFIG,
-            ),
+            (".config/dodeca.styx", STYX_CONFIG),
             (
                 "templates/index.html",
                 r#"<!DOCTYPE html>
@@ -394,10 +349,7 @@ pub fn build_step_missing_param_error() {
     let site = TestSite::with_files(
         "sample-site",
         &[
-            (
-                ".config/dodeca.styx",
-                STYX_CONFIG,
-            ),
+            (".config/dodeca.styx", STYX_CONFIG),
             (
                 "templates/index.html",
                 r#"<!DOCTYPE html>
@@ -418,7 +370,10 @@ pub fn build_step_missing_param_error() {
     html.assert_ok();
     let body = html.text();
     assert!(
-        body.contains("Missing parameter") || body.contains("error") || body.contains("Error") || body.contains("file"),
+        body.contains("Missing parameter")
+            || body.contains("error")
+            || body.contains("Error")
+            || body.contains("file"),
         "Should show error for missing parameter, got: {}",
         &body[..body.len().min(500)]
     );

--- a/crates/integration-tests/src/tests/static_assets.rs
+++ b/crates/integration-tests/src/tests/static_assets.rs
@@ -52,9 +52,10 @@ pub fn symlinked_static_files_are_served() {
     let site = TestSite::new("sample-site");
     let fixture_dir = site.fixture_dir();
 
+    let valid_font = fixture_dir.join("static/fonts/test.woff2");
     let source_file = fixture_dir.join("vendor/iosevka.woff2");
     std::fs::create_dir_all(source_file.parent().expect("source parent")).expect("create vendor");
-    std::fs::write(&source_file, b"fake-font").expect("write source font");
+    std::fs::copy(&valid_font, &source_file).expect("copy source font");
 
     let link_path = fixture_dir.join("static/fonts/iosevka.woff2");
     std::fs::create_dir_all(link_path.parent().expect("link parent")).expect("create static/fonts");

--- a/crates/integration-tests/src/tests/static_assets.rs
+++ b/crates/integration-tests/src/tests/static_assets.rs
@@ -44,3 +44,32 @@ pub fn image_files_processed() {
         svg.assert_ok();
     }
 }
+
+#[cfg(unix)]
+pub fn symlinked_static_files_are_served() {
+    use std::os::unix::fs as unix_fs;
+
+    let site = TestSite::new("sample-site");
+    let fixture_dir = site.fixture_dir();
+
+    let source_file = fixture_dir.join("vendor/iosevka.woff2");
+    std::fs::create_dir_all(source_file.parent().expect("source parent")).expect("create vendor");
+    std::fs::write(&source_file, b"fake-font").expect("write source font");
+
+    let link_path = fixture_dir.join("static/fonts/iosevka.woff2");
+    std::fs::create_dir_all(link_path.parent().expect("link parent")).expect("create static/fonts");
+    if link_path.exists() {
+        std::fs::remove_file(&link_path).expect("remove existing link");
+    }
+    unix_fs::symlink(&source_file, &link_path).expect("create font symlink");
+
+    site.wait_debounce();
+    std::thread::sleep(Duration::from_secs(1));
+
+    let resp = site.get("/fonts/iosevka.woff2");
+    assert_eq!(
+        resp.status, 200,
+        "Symlinked static files should be served (status {})",
+        resp.status
+    );
+}


### PR DESCRIPTION
## Summary
- fix Vite production CSS injection when script URLs are already rewritten to built assets
- add Sass `load_paths` plumbing so `@use` can resolve from `node_modules`
- include symlinked files when loading `static/` and `dist/`
- add regressions for built-script CSS injection and symlinked static serving

## Issues
- closes #239
- closes #240

## Notes
- this currently allows filesystem fallback reads in the Sass cell for external imports
- follow-up for proper external dependency invalidation: #242

## Validation
- `cargo nextest run -p cell-html`
- `cargo check -p cell-sass -p cell-sass-proto`
- `cargo xtask integration` (currently failing in this environment; see run output in local command)
