### PR TITLE
Make `git init` optional during `init` command

### DIFF
--- a/crates/dodeca/src/init.rs
+++ b/crates/dodeca/src/init.rs
@@ -33,7 +33,11 @@ pub fn available_templates() -> Vec<Template> {
 }
 
 /// Run the init command
-pub async fn run_init(name: String, template_name: Option<String>) -> Result<()> {
+pub async fn run_init(
+    name: String,
+    template_name: Option<String>,
+    initialise_git: bool,
+) -> Result<()> {
     let target_dir = Utf8PathBuf::from(&name);
 
     // Check if directory already exists
@@ -102,8 +106,10 @@ pub async fn run_init(name: String, template_name: Option<String>) -> Result<()>
     let strip_prefix = Utf8Path::new(template.name);
     copy_template_dir(template_dir, &target_dir, &site_name, strip_prefix)?;
 
-    // Git init if not already in a repo
-    maybe_git_init(&target_dir);
+    if initialise_git {
+        // Git init if not already in a repo
+        maybe_git_init(&target_dir);
+    }
 
     // Success message
     println!("\n{} To get started:\n", "Done!".green().bold());

--- a/crates/dodeca/src/main.rs
+++ b/crates/dodeca/src/main.rs
@@ -195,6 +195,10 @@ struct InitArgs {
     /// Template to use (skips interactive selection)
     #[facet(args::named, args::short = 't', default)]
     template: Option<String>,
+
+    /// Skip initialising Git in the new directory
+    #[facet(args::named, rename = "skip-git-init", default)]
+    skip_git_init: bool,
 }
 
 /// Term command arguments
@@ -512,7 +516,7 @@ async fn async_main(command: Command) -> Result<()> {
             // Initialize tracing early so errors are visible
             logging::init_standard_tracing();
 
-            init::run_init(args.name, args.template).await
+            init::run_init(args.name, args.template, !args.skip_git_init).await
         }
         Command::Term(args) => run_term(args).await,
     }


### PR DESCRIPTION
It still defaults to attempting to initialise git in the new directory, but allows disabling it if required.