### PR TITLE
Add Alt-E click-to-open-source devtools picker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1741,6 +1741,7 @@ dependencies = [
  "cell-markdown-proto",
  "dodeca-cell-runtime",
  "marq",
+ "pikru",
 ]
 
 [[package]]
@@ -5108,9 +5109,9 @@ dependencies = [
 
 [[package]]
 name = "marq"
-version = "2.2.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1318e643433688d5be06f48f422055a1661e6eee35c44c5322ba4354919f7537"
+checksum = "908cd24fdedda12112c778995e3d9de10151a0fa0587208b6700af8bc86e320f"
 dependencies = [
  "aasvg",
  "arborium",
@@ -5118,7 +5119,6 @@ dependencies = [
  "facet-toml",
  "facet-value",
  "facet-yaml",
- "pikru",
  "pulldown-cmark",
  "regex",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -160,7 +160,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2757,7 +2757,7 @@ checksum = "ad5208a115eaba24916f7456929832e310a81518c641f93fee4f89aa93aa3675"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3034,7 +3034,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4678,7 +4678,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5109,9 +5109,9 @@ dependencies = [
 
 [[package]]
 name = "marq"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "908cd24fdedda12112c778995e3d9de10151a0fa0587208b6700af8bc86e320f"
+checksum = "15cb5733128da96deafd4b5b91c8f07128baf98930bd7fb5db0ba5dac2c105cb"
 dependencies = [
  "aasvg",
  "arborium",
@@ -5460,7 +5460,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7191,7 +7191,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7248,7 +7248,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7682,7 +7682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8086,7 +8086,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9598,7 +9598,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1741,7 +1741,6 @@ dependencies = [
  "cell-markdown-proto",
  "dodeca-cell-runtime",
  "marq",
- "pikru",
 ]
 
 [[package]]
@@ -5109,9 +5108,9 @@ dependencies = [
 
 [[package]]
 name = "marq"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15cb5733128da96deafd4b5b91c8f07128baf98930bd7fb5db0ba5dac2c105cb"
+checksum = "818938e375b1ed3c2791d4be0f456e79bb5e75b7fe595186d2448492ab7ccd30"
 dependencies = [
  "aasvg",
  "arborium",
@@ -5119,6 +5118,7 @@ dependencies = [
  "facet-toml",
  "facet-value",
  "facet-yaml",
+ "pikru",
  "pulldown-cmark",
  "regex",
  "thiserror 2.0.18",

--- a/cells/cell-markdown-proto/src/lib.rs
+++ b/cells/cell-markdown-proto/src/lib.rs
@@ -81,6 +81,52 @@ pub struct ReqDefinition {
     pub anchor_id: String,
 }
 
+/// Markdown construct represented by a source-map entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Facet)]
+#[repr(u8)]
+pub enum SourceKind {
+    Heading,
+    Paragraph,
+    BlockQuote,
+    List,
+    ListItem,
+    DefinitionList,
+    DefinitionListTitle,
+    DefinitionListDefinition,
+    ThematicBreak,
+    Table,
+    TableHead,
+    TableRow,
+    TableCell,
+    Image,
+}
+
+/// Source information for one rendered HTML element.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Facet)]
+pub struct SourceMapEntry {
+    /// ID emitted as `data-sid`.
+    pub id: String,
+    /// Markdown construct represented by this entry.
+    pub kind: SourceKind,
+    /// Inclusive 1-indexed starting line.
+    pub line_start: u32,
+    /// Inclusive 1-indexed ending line.
+    pub line_end: u32,
+    /// Inclusive starting byte offset in the source markdown.
+    pub byte_start: u64,
+    /// Exclusive ending byte offset in the source markdown.
+    pub byte_end: u64,
+}
+
+/// Sidecar map from rendered `data-sid` attributes back to markdown spans.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, Facet)]
+pub struct SourceMap {
+    /// Source path for all entries, when provided by marq.
+    pub source_path: Option<String>,
+    /// Entries in render order.
+    pub entries: Vec<SourceMapEntry>,
+}
+
 /// Parsed frontmatter fields
 #[derive(Debug, Clone, Default, Facet)]
 pub struct Frontmatter {
@@ -110,6 +156,8 @@ pub enum MarkdownResult {
         reqs: Vec<ReqDefinition>,
         /// HTML snippets to inject into the page's `<head>` (deduplicated by key)
         head_injections: Vec<String>,
+        /// Source map for rendered elements with `data-sid` attributes.
+        source_map: Box<SourceMap>,
     },
     /// Error during rendering
     Error { message: String },
@@ -152,6 +200,8 @@ pub enum ParseResult {
         reqs: Vec<ReqDefinition>,
         /// HTML snippets to inject into the page's `<head>` (deduplicated by key)
         head_injections: Vec<String>,
+        /// Source map for rendered elements with `data-sid` attributes.
+        source_map: Box<SourceMap>,
     },
     /// Error during parsing
     Error { message: String },
@@ -180,7 +230,13 @@ pub trait MarkdownProcessor {
     /// # Parameters
     /// - `source_path`: Path to the source file (e.g., "spec/_index.md") for resolving relative links
     /// - `markdown`: The markdown content to render
-    async fn render_markdown(&self, source_path: String, markdown: String) -> MarkdownResult;
+    /// - `source_map`: Whether to emit `data-sid` attributes and return a source map
+    async fn render_markdown(
+        &self,
+        source_path: String,
+        markdown: String,
+        source_map: bool,
+    ) -> MarkdownResult;
 
     /// Parse frontmatter and render markdown in one call.
     ///
@@ -189,7 +245,13 @@ pub trait MarkdownProcessor {
     /// # Parameters
     /// - `source_path`: Path to the source file (e.g., "spec/_index.md") for resolving relative links
     /// - `content`: The full content including frontmatter and markdown body
-    async fn parse_and_render(&self, source_path: String, content: String) -> ParseResult;
+    /// - `source_map`: Whether to emit `data-sid` attributes and return a source map
+    async fn parse_and_render(
+        &self,
+        source_path: String,
+        content: String,
+        source_map: bool,
+    ) -> ParseResult;
 
     /// Highlight a code snippet with syntax coloring.
     ///

--- a/cells/cell-markdown/Cargo.toml
+++ b/cells/cell-markdown/Cargo.toml
@@ -17,8 +17,8 @@ path = "src/main.rs"
 [dependencies]
 cell-markdown-proto = { path = "../cell-markdown-proto" }
 dodeca-cell-runtime = { path = "../../crates/dodeca-cell-runtime" }
-marq = { version = "4.0.0", features = [
+marq = { version = "4.0.1", features = [
   "aasvg",
   "highlight",
+  "pikru",
 ] }
-pikru = "1.2"

--- a/cells/cell-markdown/Cargo.toml
+++ b/cells/cell-markdown/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 [dependencies]
 cell-markdown-proto = { path = "../cell-markdown-proto" }
 dodeca-cell-runtime = { path = "../../crates/dodeca-cell-runtime" }
-marq = { version = "3.0.0", features = [
+marq = { version = "4.0.0", features = [
   "aasvg",
   "highlight",
 ] }

--- a/cells/cell-markdown/Cargo.toml
+++ b/cells/cell-markdown/Cargo.toml
@@ -17,8 +17,8 @@ path = "src/main.rs"
 [dependencies]
 cell-markdown-proto = { path = "../cell-markdown-proto" }
 dodeca-cell-runtime = { path = "../../crates/dodeca-cell-runtime" }
-marq = { version = "2.2.2", features = [
+marq = { version = "3.0.0", features = [
   "aasvg",
   "highlight",
-  "pikru",
 ] }
+pikru = "1.2"

--- a/cells/cell-markdown/src/main.rs
+++ b/cells/cell-markdown/src/main.rs
@@ -7,7 +7,7 @@ use cell_markdown_proto::*;
 use dodeca_cell_runtime::HostHandle;
 use marq::{
     AasvgHandler, ArboriumHandler, CompareHandler, InlineCodeHandler, LinkResolver, MermaidHandler,
-    RenderOptions, TermHandler, render,
+    PikruHandler, RenderOptions, TermHandler, render,
 };
 use std::future::Future;
 use std::pin::Pin;
@@ -78,51 +78,6 @@ impl LinkResolver for PassthroughLinkResolver {
     }
 }
 
-/// Pikchr handler kept in Dodeca until the published Marq handler catches up
-/// with `pikru`'s current RenderOptions shape.
-struct DodecaPikruHandler {
-    css_variables: bool,
-}
-
-impl DodecaPikruHandler {
-    fn with_css_variables(css_variables: bool) -> Self {
-        Self { css_variables }
-    }
-}
-
-impl marq::CodeBlockHandler for DodecaPikruHandler {
-    fn render<'a>(
-        &'a self,
-        _language: &'a str,
-        code: &'a str,
-    ) -> Pin<Box<dyn Future<Output = marq::Result<marq::CodeBlockOutput>> + Send + 'a>> {
-        Box::pin(async move {
-            let program = pikru::parse::parse(code).map_err(|e| marq::Error::CodeBlockHandler {
-                language: "pik".to_string(),
-                message: format!("parse error: {e}"),
-            })?;
-
-            let program = pikru::macros::expand_macros(program).map_err(|e| {
-                marq::Error::CodeBlockHandler {
-                    language: "pik".to_string(),
-                    message: format!("macro error: {e}"),
-                }
-            })?;
-
-            let options = pikru::render::RenderOptions {
-                css_variables: self.css_variables,
-                explicit_size: false,
-            };
-            pikru::render::render_with_options(&program, &options)
-                .map(Into::into)
-                .map_err(|e| marq::Error::CodeBlockHandler {
-                    language: "pik".to_string(),
-                    message: format!("render error: {e}"),
-                })
-        })
-    }
-}
-
 #[derive(Clone)]
 pub struct MarkdownProcessorImpl;
 
@@ -137,7 +92,7 @@ fn render_options(source_path: &str, source_map: bool) -> RenderOptions {
     RenderOptions::new()
         .with_handler(&["aa", "aasvg"], AasvgHandler::new())
         .with_handler(&["compare"], CompareHandler::new())
-        .with_handler(&["pikchr"], DodecaPikruHandler::with_css_variables(true))
+        .with_handler(&["pikchr"], PikruHandler::with_css_variables(true))
         .with_handler(&["term"], TermHandler::new())
         .with_handler(&["mermaid"], MermaidHandler::new())
         .with_default_handler(ArboriumHandler::new())

--- a/cells/cell-markdown/src/main.rs
+++ b/cells/cell-markdown/src/main.rs
@@ -7,7 +7,7 @@ use cell_markdown_proto::*;
 use dodeca_cell_runtime::HostHandle;
 use marq::{
     AasvgHandler, ArboriumHandler, CompareHandler, InlineCodeHandler, LinkResolver, MermaidHandler,
-    PikruHandler, RenderOptions, TermHandler, render,
+    RenderOptions, TermHandler, render,
 };
 use std::future::Future;
 use std::pin::Pin;
@@ -78,6 +78,51 @@ impl LinkResolver for PassthroughLinkResolver {
     }
 }
 
+/// Pikchr handler kept in Dodeca until the published Marq handler catches up
+/// with `pikru`'s current RenderOptions shape.
+struct DodecaPikruHandler {
+    css_variables: bool,
+}
+
+impl DodecaPikruHandler {
+    fn with_css_variables(css_variables: bool) -> Self {
+        Self { css_variables }
+    }
+}
+
+impl marq::CodeBlockHandler for DodecaPikruHandler {
+    fn render<'a>(
+        &'a self,
+        _language: &'a str,
+        code: &'a str,
+    ) -> Pin<Box<dyn Future<Output = marq::Result<marq::CodeBlockOutput>> + Send + 'a>> {
+        Box::pin(async move {
+            let program = pikru::parse::parse(code).map_err(|e| marq::Error::CodeBlockHandler {
+                language: "pik".to_string(),
+                message: format!("parse error: {e}"),
+            })?;
+
+            let program = pikru::macros::expand_macros(program).map_err(|e| {
+                marq::Error::CodeBlockHandler {
+                    language: "pik".to_string(),
+                    message: format!("macro error: {e}"),
+                }
+            })?;
+
+            let options = pikru::render::RenderOptions {
+                css_variables: self.css_variables,
+                explicit_size: false,
+            };
+            pikru::render::render_with_options(&program, &options)
+                .map(Into::into)
+                .map_err(|e| marq::Error::CodeBlockHandler {
+                    language: "pik".to_string(),
+                    message: format!("render error: {e}"),
+                })
+        })
+    }
+}
+
 #[derive(Clone)]
 pub struct MarkdownProcessorImpl;
 
@@ -86,6 +131,22 @@ impl MarkdownProcessorImpl {
         // The markdown cell does not call back into the host.
         Self
     }
+}
+
+fn render_options(source_path: &str, source_map: bool) -> RenderOptions {
+    RenderOptions::new()
+        .with_handler(&["aa", "aasvg"], AasvgHandler::new())
+        .with_handler(&["compare"], CompareHandler::new())
+        .with_handler(&["pikchr"], DodecaPikruHandler::with_css_variables(true))
+        .with_handler(&["term"], TermHandler::new())
+        .with_handler(&["mermaid"], MermaidHandler::new())
+        .with_default_handler(ArboriumHandler::new())
+        .with_source_path(source_path)
+        .with_source_map(source_map)
+        // Pass through @/ links unchanged - dodeca will resolve them with site tree
+        .with_link_resolver(PassthroughLinkResolver)
+        // Convert rule marker inline code to links
+        .with_inline_code_handler(RuleRefHandler)
 }
 
 impl MarkdownProcessor for MarkdownProcessorImpl {
@@ -101,20 +162,13 @@ impl MarkdownProcessor for MarkdownProcessorImpl {
         }
     }
 
-    async fn render_markdown(&self, source_path: String, markdown: String) -> MarkdownResult {
-        // Configure marq with real handlers (no placeholders!)
-        let opts = RenderOptions::new()
-            .with_handler(&["aa", "aasvg"], AasvgHandler::new())
-            .with_handler(&["compare"], CompareHandler::new())
-            .with_handler(&["pikchr"], PikruHandler::with_css_variables(true))
-            .with_handler(&["term"], TermHandler::new())
-            .with_handler(&["mermaid"], MermaidHandler::new())
-            .with_default_handler(ArboriumHandler::new())
-            .with_source_path(&source_path)
-            // Pass through @/ links unchanged - dodeca will resolve them with site tree
-            .with_link_resolver(PassthroughLinkResolver)
-            // Convert rule marker inline code to links
-            .with_inline_code_handler(RuleRefHandler);
+    async fn render_markdown(
+        &self,
+        source_path: String,
+        markdown: String,
+        source_map: bool,
+    ) -> MarkdownResult {
+        let opts = render_options(&source_path, source_map);
 
         // Render markdown with all code blocks rendered inline
         match render(&markdown, &opts).await {
@@ -123,6 +177,7 @@ impl MarkdownProcessor for MarkdownProcessorImpl {
                 headings: doc.headings.into_iter().map(convert_heading).collect(),
                 reqs: doc.reqs.into_iter().map(convert_req).collect(),
                 head_injections: doc.head_injections,
+                source_map: Box::new(convert_source_map(doc.source_map)),
             },
             Err(e) => MarkdownResult::Error {
                 message: e.to_string(),
@@ -149,9 +204,14 @@ impl MarkdownProcessor for MarkdownProcessorImpl {
         }
     }
 
-    async fn parse_and_render(&self, source_path: String, content: String) -> ParseResult {
+    async fn parse_and_render(
+        &self,
+        source_path: String,
+        content: String,
+        source_map: bool,
+    ) -> ParseResult {
         // Parse frontmatter
-        let (fm, body) = match marq::parse_frontmatter(&content) {
+        let (fm, _) = match marq::parse_frontmatter(&content) {
             Ok(result) => result,
             Err(e) => {
                 return ParseResult::Error {
@@ -160,19 +220,22 @@ impl MarkdownProcessor for MarkdownProcessorImpl {
             }
         };
 
-        // Render markdown body
-        match self.render_markdown(source_path, body.to_string()).await {
+        // Render the full document so source-map line and byte ranges refer to
+        // the actual source file, including any frontmatter offset.
+        match self.render_markdown(source_path, content, source_map).await {
             MarkdownResult::Success {
                 html,
                 headings,
                 reqs,
                 head_injections,
+                source_map,
             } => ParseResult::Success {
                 frontmatter: convert_frontmatter(fm),
                 html,
                 headings,
                 reqs,
                 head_injections,
+                source_map,
             },
             MarkdownResult::Error { message } => ParseResult::Error { message },
         }
@@ -202,6 +265,43 @@ fn convert_req(r: marq::ReqDefinition) -> ReqDefinition {
     ReqDefinition {
         id: r.id.to_string(),
         anchor_id: r.anchor_id,
+    }
+}
+
+fn convert_source_kind(kind: marq::SourceKind) -> SourceKind {
+    match kind {
+        marq::SourceKind::Heading => SourceKind::Heading,
+        marq::SourceKind::Paragraph => SourceKind::Paragraph,
+        marq::SourceKind::BlockQuote => SourceKind::BlockQuote,
+        marq::SourceKind::List => SourceKind::List,
+        marq::SourceKind::ListItem => SourceKind::ListItem,
+        marq::SourceKind::DefinitionList => SourceKind::DefinitionList,
+        marq::SourceKind::DefinitionListTitle => SourceKind::DefinitionListTitle,
+        marq::SourceKind::DefinitionListDefinition => SourceKind::DefinitionListDefinition,
+        marq::SourceKind::ThematicBreak => SourceKind::ThematicBreak,
+        marq::SourceKind::Table => SourceKind::Table,
+        marq::SourceKind::TableHead => SourceKind::TableHead,
+        marq::SourceKind::TableRow => SourceKind::TableRow,
+        marq::SourceKind::TableCell => SourceKind::TableCell,
+        marq::SourceKind::Image => SourceKind::Image,
+    }
+}
+
+fn convert_source_map(source_map: marq::SourceMap) -> SourceMap {
+    SourceMap {
+        source_path: source_map.source_path,
+        entries: source_map
+            .entries
+            .into_iter()
+            .map(|entry| SourceMapEntry {
+                id: entry.id.as_str().to_string(),
+                kind: convert_source_kind(entry.kind),
+                line_start: entry.line_start as u32,
+                line_end: entry.line_end as u32,
+                byte_start: entry.byte_start as u64,
+                byte_end: entry.byte_end as u64,
+            })
+            .collect(),
     }
 }
 

--- a/crates/dodeca-devtools/Cargo.toml
+++ b/crates/dodeca-devtools/Cargo.toml
@@ -41,6 +41,16 @@ features = [
     "MessageEvent",
     "ErrorEvent",
     "CloseEvent",
+    "CssStyleDeclaration",
+    "Document",
+    "DomRect",
+    "Element",
+    "EventTarget",
+    "HtmlElement",
+    "KeyboardEvent",
+    "MouseEvent",
+    "Node",
+    "Window",
 ]
 
 [dev-dependencies]

--- a/crates/dodeca-devtools/src/lib.rs
+++ b/crates/dodeca-devtools/src/lib.rs
@@ -11,6 +11,7 @@
 use sycamore::prelude::*;
 use wasm_bindgen::prelude::*;
 
+mod open_in_editor;
 mod protocol;
 mod state;
 
@@ -33,6 +34,7 @@ pub fn mount_devtools() {
             DevtoolsApp {}
         }
     });
+    open_in_editor::install();
 }
 
 /// Main devtools application component

--- a/crates/dodeca-devtools/src/open_in_editor.rs
+++ b/crates/dodeca-devtools/src/open_in_editor.rs
@@ -1,0 +1,203 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use wasm_bindgen::{JsCast, closure::Closure};
+use web_sys::{Document, Element, HtmlElement, KeyboardEvent, MouseEvent};
+
+#[derive(Clone)]
+struct SourceTarget {
+    element: Element,
+    source_file: String,
+    line: u32,
+}
+
+struct PickerState {
+    active: bool,
+    mouse_x: f64,
+    mouse_y: f64,
+    target: Option<SourceTarget>,
+    highlight: HtmlElement,
+}
+
+pub fn install() {
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let Some(document) = window.document() else {
+        return;
+    };
+    let Some(body) = document.body() else {
+        return;
+    };
+    let Ok(highlight) = document.create_element("div") else {
+        return;
+    };
+    let Ok(highlight) = highlight.dyn_into::<HtmlElement>() else {
+        return;
+    };
+
+    highlight.set_class_name("dodeca-source-picker-highlight");
+    highlight.set_text_content(Some("Open in editor"));
+    let style = highlight.style();
+    let _ = style.set_property("display", "none");
+    let _ = style.set_property("position", "fixed");
+    let _ = style.set_property("z-index", "99998");
+    let _ = style.set_property("pointer-events", "none");
+    let _ = style.set_property("box-sizing", "border-box");
+    let _ = style.set_property("border", "2px solid #22c55e");
+    let _ = style.set_property("background", "rgba(34, 197, 94, 0.08)");
+    let _ = style.set_property("color", "#052e16");
+    let _ = style.set_property("font", "600 12px system-ui, sans-serif");
+    let _ = style.set_property("padding", "4px 6px");
+    let _ = style.set_property("border-radius", "4px");
+    let _ = style.set_property("box-shadow", "0 0 0 9999px rgba(0, 0, 0, 0.04)");
+
+    let _ = body.append_child(&highlight);
+
+    let state = Rc::new(RefCell::new(PickerState {
+        active: false,
+        mouse_x: 0.0,
+        mouse_y: 0.0,
+        target: None,
+        highlight,
+    }));
+
+    let key_document = document.clone();
+    let key_state = state.clone();
+    let on_keydown = Closure::<dyn FnMut(KeyboardEvent)>::wrap(Box::new(move |event| {
+        if event.code() == "KeyE" && event.alt_key() {
+            event.prevent_default();
+            let mut state = key_state.borrow_mut();
+            state.active = !state.active;
+            set_body_cursor(
+                &key_document,
+                if state.active { "crosshair" } else { "default" },
+            );
+            update_target(&key_document, &mut state);
+        } else if event.code() == "Escape" {
+            let mut state = key_state.borrow_mut();
+            if state.active {
+                event.prevent_default();
+                state.active = false;
+                state.target = None;
+                set_body_cursor(&key_document, "default");
+                hide_highlight(&state.highlight);
+            }
+        }
+    }));
+    let _ =
+        document.add_event_listener_with_callback("keydown", on_keydown.as_ref().unchecked_ref());
+    on_keydown.forget();
+
+    let move_document = document.clone();
+    let move_state = state.clone();
+    let on_mousemove = Closure::<dyn FnMut(MouseEvent)>::wrap(Box::new(move |event| {
+        let mut state = move_state.borrow_mut();
+        state.mouse_x = event.client_x() as f64;
+        state.mouse_y = event.client_y() as f64;
+        update_target(&move_document, &mut state);
+    }));
+    let _ = document
+        .add_event_listener_with_callback("mousemove", on_mousemove.as_ref().unchecked_ref());
+    on_mousemove.forget();
+
+    let scroll_document = document.clone();
+    let scroll_state = state.clone();
+    let on_scroll = Closure::<dyn FnMut()>::wrap(Box::new(move || {
+        update_target(&scroll_document, &mut scroll_state.borrow_mut());
+    }));
+    let _ = document.add_event_listener_with_callback("scroll", on_scroll.as_ref().unchecked_ref());
+    on_scroll.forget();
+
+    let click_document = document.clone();
+    let click_state = state.clone();
+    let on_click = Closure::<dyn FnMut(MouseEvent)>::wrap(Box::new(move |event| {
+        let target = {
+            let mut state = click_state.borrow_mut();
+            if !state.active {
+                return;
+            }
+            event.prevent_default();
+            event.stop_propagation();
+            state.active = false;
+            set_body_cursor(&click_document, "default");
+            hide_highlight(&state.highlight);
+            state.target.take()
+        };
+
+        if let Some(target) = target {
+            crate::state::open_source(target.source_file, target.line);
+        }
+    }));
+    let _ = document.add_event_listener_with_callback("click", on_click.as_ref().unchecked_ref());
+    on_click.forget();
+}
+
+fn update_target(document: &Document, state: &mut PickerState) {
+    if !state.active {
+        state.target = None;
+        hide_highlight(&state.highlight);
+        return;
+    }
+
+    state.target = find_source_target(document, state.mouse_x, state.mouse_y);
+    match &state.target {
+        Some(target) => {
+            set_body_cursor(document, "text");
+            show_highlight(&state.highlight, &target.element);
+        }
+        None => {
+            set_body_cursor(document, "not-allowed");
+            hide_highlight(&state.highlight);
+        }
+    }
+}
+
+fn find_source_target(document: &Document, x: f64, y: f64) -> Option<SourceTarget> {
+    let element = document.element_from_point(x as f32, y as f32)?;
+    if element
+        .closest(".dodeca-devtools, .dodeca-source-picker-highlight")
+        .ok()
+        .flatten()
+        .is_some()
+    {
+        return None;
+    }
+
+    let element = element
+        .closest("[data-source-file][data-source-line]")
+        .ok()
+        .flatten()?;
+    let source_file = element.get_attribute("data-source-file")?;
+    let line = element
+        .get_attribute("data-source-line")?
+        .parse::<u32>()
+        .ok()
+        .filter(|line| *line > 0)?;
+
+    Some(SourceTarget {
+        element,
+        source_file,
+        line,
+    })
+}
+
+fn show_highlight(highlight: &HtmlElement, element: &Element) {
+    let rect = element.get_bounding_client_rect();
+    let style = highlight.style();
+    let _ = style.set_property("display", "block");
+    let _ = style.set_property("top", &format!("{}px", rect.top() - 8.0));
+    let _ = style.set_property("left", &format!("{}px", rect.left() - 8.0));
+    let _ = style.set_property("width", &format!("{}px", rect.width() + 16.0));
+    let _ = style.set_property("min-height", &format!("{}px", rect.height() + 16.0));
+}
+
+fn hide_highlight(highlight: &HtmlElement) {
+    let _ = highlight.style().set_property("display", "none");
+}
+
+fn set_body_cursor(document: &Document, cursor: &str) {
+    if let Some(body) = document.body() {
+        let _ = body.style().set_property("cursor", cursor);
+    }
+}

--- a/crates/dodeca-devtools/src/open_in_editor.rs
+++ b/crates/dodeca-devtools/src/open_in_editor.rs
@@ -7,8 +7,7 @@ use web_sys::{Document, Element, HtmlElement, KeyboardEvent, MouseEvent};
 #[derive(Clone)]
 struct SourceTarget {
     element: Element,
-    source_file: String,
-    line: u32,
+    sid: String,
 }
 
 struct PickerState {
@@ -126,7 +125,13 @@ pub fn install() {
         };
 
         if let Some(target) = target {
-            crate::state::open_source(target.source_file, target.line);
+            tracing::debug!(
+                sid = %target.sid,
+                "[devtools] source picker target clicked"
+            );
+            crate::state::open_source_id(target.sid);
+        } else {
+            tracing::debug!("[devtools] source picker clicked without a source target");
         }
     }));
     let _ = document.add_event_listener_with_callback("click", on_click.as_ref().unchecked_ref());
@@ -164,22 +169,10 @@ fn find_source_target(document: &Document, x: f64, y: f64) -> Option<SourceTarge
         return None;
     }
 
-    let element = element
-        .closest("[data-source-file][data-source-line]")
-        .ok()
-        .flatten()?;
-    let source_file = element.get_attribute("data-source-file")?;
-    let line = element
-        .get_attribute("data-source-line")?
-        .parse::<u32>()
-        .ok()
-        .filter(|line| *line > 0)?;
+    let element = element.closest("[data-sid]").ok().flatten()?;
+    let sid = element.get_attribute("data-sid")?;
 
-    Some(SourceTarget {
-        element,
-        source_file,
-        line,
-    })
+    Some(SourceTarget { element, sid })
 }
 
 fn show_highlight(highlight: &HtmlElement, element: &Element) {

--- a/crates/dodeca-devtools/src/state.rs
+++ b/crates/dodeca-devtools/src/state.rs
@@ -461,6 +461,12 @@ pub fn dismiss_error(route: String) {
 
 /// Open a source location in the host editor.
 pub fn open_source(source_file: String, line: u32) {
+    tracing::debug!(
+        source_file = %source_file,
+        line,
+        "[devtools] requesting open_source RPC"
+    );
+
     let Some(client) = get_client() else {
         tracing::warn!(
             source_file,
@@ -480,6 +486,39 @@ pub fn open_source(source_file: String, line: u32) {
             }
             Err(err) => {
                 tracing::error!(source_file, line, ?err, "[devtools] open_source RPC failed");
+            }
+        }
+    });
+}
+
+/// Open a rendered markdown element in the host editor.
+pub fn open_source_id(sid: String) {
+    let route = current_route();
+    tracing::debug!(
+        route = %route,
+        sid = %sid,
+        "[devtools] requesting open_source_id RPC"
+    );
+
+    let Some(client) = get_client() else {
+        tracing::warn!(
+            route,
+            sid,
+            "[devtools] open_source_id requested before RPC client was ready"
+        );
+        return;
+    };
+
+    wasm_bindgen_futures::spawn_local(async move {
+        match client.open_source_id(route.clone(), sid.clone()).await {
+            Ok(OpenSourceResult::Ok) => {
+                tracing::info!(route, sid, "[devtools] open_source_id succeeded");
+            }
+            Ok(OpenSourceResult::Err(err)) => {
+                tracing::warn!(route, sid, err, "[devtools] open_source_id failed");
+            }
+            Err(err) => {
+                tracing::error!(route, sid, ?err, "[devtools] open_source_id RPC failed");
             }
         }
     });

--- a/crates/dodeca-devtools/src/state.rs
+++ b/crates/dodeca-devtools/src/state.rs
@@ -7,7 +7,7 @@ use wasm_bindgen::JsCast;
 
 use crate::protocol::{
     BrowserService, BrowserServiceDispatcher, DevtoolsEvent, DevtoolsServiceClient, ErrorInfo,
-    ScopeEntry, ScopeValue,
+    OpenSourceResult, ScopeEntry, ScopeValue,
 };
 use vox::FromVoxSession;
 use vox_websocket::WsLink;
@@ -455,6 +455,32 @@ pub fn dismiss_error(route: String) {
     wasm_bindgen_futures::spawn_local(async move {
         if let Err(e) = client.dismiss_error(route).await {
             tracing::error!("[devtools] dismiss_error failed: {:?}", e);
+        }
+    });
+}
+
+/// Open a source location in the host editor.
+pub fn open_source(source_file: String, line: u32) {
+    let Some(client) = get_client() else {
+        tracing::warn!(
+            source_file,
+            line,
+            "[devtools] open_source requested before RPC client was ready"
+        );
+        return;
+    };
+
+    wasm_bindgen_futures::spawn_local(async move {
+        match client.open_source(source_file.clone(), line).await {
+            Ok(OpenSourceResult::Ok) => {
+                tracing::info!(source_file, line, "[devtools] open_source succeeded");
+            }
+            Ok(OpenSourceResult::Err(err)) => {
+                tracing::warn!(source_file, line, err, "[devtools] open_source failed");
+            }
+            Err(err) => {
+                tracing::error!(source_file, line, ?err, "[devtools] open_source RPC failed");
+            }
         }
     });
 }

--- a/crates/dodeca-protocol/src/lib.rs
+++ b/crates/dodeca-protocol/src/lib.rs
@@ -70,6 +70,9 @@ pub trait DevtoolsService {
 
     /// Open a rendered source location in the developer's editor.
     async fn open_source(&self, source_file: String, line: u32) -> OpenSourceResult;
+
+    /// Open a rendered markdown element by route and `data-sid`.
+    async fn open_source_id(&self, route: String, sid: String) -> OpenSourceResult;
 }
 
 /// Events pushed from server to browser devtools.

--- a/crates/dodeca-protocol/src/lib.rs
+++ b/crates/dodeca-protocol/src/lib.rs
@@ -67,6 +67,9 @@ pub trait DevtoolsService {
     ///
     /// Called when the user acknowledges an error.
     async fn dismiss_error(&self, route: String);
+
+    /// Open a rendered source location in the developer's editor.
+    async fn open_source(&self, source_file: String, line: u32) -> OpenSourceResult;
 }
 
 /// Events pushed from server to browser devtools.
@@ -87,6 +90,13 @@ pub enum DevtoolsEvent {
 
     /// Error was resolved (template now renders successfully)
     ErrorResolved { route: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Facet)]
+#[repr(u8)]
+pub enum OpenSourceResult {
+    Ok,
+    Err(String),
 }
 
 // ============================================================================

--- a/crates/dodeca/src/cell_server.rs
+++ b/crates/dodeca/src/cell_server.rs
@@ -41,7 +41,7 @@ pub fn find_cell_path() -> Result<std::path::PathBuf> {
 // HostDevtoolsService - vox RPC implementation of DevtoolsService
 // ============================================================================
 
-use dodeca_protocol::{DevtoolsEvent, DevtoolsService, EvalResult, ScopeEntry};
+use dodeca_protocol::{DevtoolsEvent, DevtoolsService, EvalResult, OpenSourceResult, ScopeEntry};
 
 /// Host-side implementation of DevtoolsService for direct vox RPC.
 ///
@@ -133,6 +133,13 @@ impl DevtoolsService for HostDevtoolsService {
         tracing::debug!(route = %route, "Client dismissed error via RPC");
         // The existing implementation just logs this - errors are resolved
         // when the template successfully re-renders
+    }
+
+    async fn open_source(&self, source_file: String, line: u32) -> OpenSourceResult {
+        match self.server.open_source_in_editor(&source_file, line).await {
+            Ok(()) => OpenSourceResult::Ok,
+            Err(err) => OpenSourceResult::Err(err.to_string()),
+        }
     }
 }
 

--- a/crates/dodeca/src/cell_server.rs
+++ b/crates/dodeca/src/cell_server.rs
@@ -136,10 +136,67 @@ impl DevtoolsService for HostDevtoolsService {
     }
 
     async fn open_source(&self, source_file: String, line: u32) -> OpenSourceResult {
-        match self.server.open_source_in_editor(&source_file, line).await {
+        tracing::debug!(
+            browser_id = self.browser_id,
+            source_file = %source_file,
+            line,
+            "devtools open_source RPC received"
+        );
+
+        let result = match self.server.open_source_in_editor(&source_file, line).await {
             Ok(()) => OpenSourceResult::Ok,
             Err(err) => OpenSourceResult::Err(err.to_string()),
+        };
+
+        match &result {
+            OpenSourceResult::Ok => tracing::debug!(
+                browser_id = self.browser_id,
+                source_file = %source_file,
+                line,
+                "devtools open_source RPC succeeded"
+            ),
+            OpenSourceResult::Err(err) => tracing::debug!(
+                browser_id = self.browser_id,
+                source_file = %source_file,
+                line,
+                error = %err,
+                "devtools open_source RPC failed"
+            ),
         }
+
+        result
+    }
+
+    async fn open_source_id(&self, route: String, sid: String) -> OpenSourceResult {
+        tracing::debug!(
+            browser_id = self.browser_id,
+            route = %route,
+            sid = %sid,
+            "devtools open_source_id RPC received"
+        );
+
+        let result = match self.server.open_source_id_in_editor(&route, &sid).await {
+            Ok(()) => OpenSourceResult::Ok,
+            Err(err) => OpenSourceResult::Err(err.to_string()),
+        };
+
+        match &result {
+            OpenSourceResult::Ok => tracing::debug!(
+                browser_id = self.browser_id,
+                route = %route,
+                sid = %sid,
+                "devtools open_source_id RPC succeeded"
+            ),
+            OpenSourceResult::Err(err) => tracing::debug!(
+                browser_id = self.browser_id,
+                route = %route,
+                sid = %sid,
+                error = %err,
+                "devtools open_source_id RPC failed"
+            ),
+        }
+
+        result
     }
 }
 

--- a/crates/dodeca/src/cells.rs
+++ b/crates/dodeca/src/cells.rs
@@ -612,12 +612,13 @@ pub async fn highlight_code_cell(lang: &str, code: &str) -> Result<String, eyre:
 pub async fn parse_and_render_markdown_cell(
     source_path: &str,
     content: &str,
+    source_map: bool,
 ) -> Result<cell_markdown_proto::ParseResult, MarkdownParseError> {
     let client = markdown_cell().await.ok_or_else(|| MarkdownParseError {
         message: "Markdown cell not available".to_string(),
     })?;
     client
-        .parse_and_render(source_path.to_string(), content.to_string())
+        .parse_and_render(source_path.to_string(), content.to_string(), source_map)
         .await
         .map_err(|e| MarkdownParseError {
             message: format!("RPC error: {:?}", e),

--- a/crates/dodeca/src/db.rs
+++ b/crates/dodeca/src/db.rs
@@ -126,6 +126,13 @@ pub struct SourceRegistry {
     pub sources: Vec<SourceFile>,
 }
 
+/// Markdown rendering settings that affect parsed HTML output.
+#[picante::input]
+pub struct MarkdownRenderSettings {
+    /// Whether markdown rendering should emit `data-sid` attributes and source maps.
+    pub source_maps: bool,
+}
+
 /// Interned character set for font subsetting
 /// Using a sorted Vec<char> for deterministic hashing
 #[picante::interned]
@@ -157,6 +164,58 @@ pub struct ReqDefinition {
     pub anchor_id: String,
 }
 
+/// Markdown construct represented by a source-map entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, facet::Facet)]
+#[repr(u8)]
+pub enum SourceKind {
+    Heading,
+    Paragraph,
+    BlockQuote,
+    List,
+    ListItem,
+    DefinitionList,
+    DefinitionListTitle,
+    DefinitionListDefinition,
+    ThematicBreak,
+    Table,
+    TableHead,
+    TableRow,
+    TableCell,
+    Image,
+}
+
+/// Source information for one rendered HTML element.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, facet::Facet)]
+pub struct SourceMapEntry {
+    /// ID emitted as `data-sid`.
+    pub id: String,
+    /// Markdown construct represented by this entry.
+    pub kind: SourceKind,
+    /// Inclusive 1-indexed starting line.
+    pub line_start: u32,
+    /// Inclusive 1-indexed ending line.
+    pub line_end: u32,
+    /// Inclusive starting byte offset in the source markdown.
+    pub byte_start: u64,
+    /// Exclusive ending byte offset in the source markdown.
+    pub byte_end: u64,
+}
+
+/// Sidecar map from rendered `data-sid` attributes back to markdown spans.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, facet::Facet)]
+pub struct SourceMap {
+    /// Source path for all entries.
+    pub source_path: Option<String>,
+    /// Entries in render order.
+    pub entries: Vec<SourceMapEntry>,
+}
+
+impl SourceMap {
+    pub fn get_by_sid(&self, sid: &str) -> Option<&SourceMapEntry> {
+        self.entries.iter().find(|entry| entry.id == sid)
+    }
+}
+
 /// A section in the site tree (corresponds to _index.md files)
 #[derive(Debug, Clone, PartialEq, Eq, Hash, facet::Facet)]
 pub struct Section {
@@ -169,6 +228,8 @@ pub struct Section {
     pub headings: Vec<Heading>,
     /// Requirement definitions for specification traceability
     pub reqs: Vec<ReqDefinition>,
+    /// Source map for rendered elements with `data-sid` attributes.
+    pub source_map: SourceMap,
     /// HTML snippets to inject into the page's `<head>` (e.g., Mermaid.js CDN script)
     pub head_injections: Vec<String>,
     /// Last modification time as Unix timestamp (seconds since epoch)
@@ -191,6 +252,8 @@ pub struct Page {
     pub headings: Vec<Heading>,
     /// Rule definitions for specification traceability
     pub rules: Vec<ReqDefinition>,
+    /// Source map for rendered elements with `data-sid` attributes.
+    pub source_map: SourceMap,
     /// HTML snippets to inject into the page's `<head>` (e.g., Mermaid.js CDN script)
     pub head_injections: Vec<String>,
     /// Last modification time as Unix timestamp (seconds since epoch)
@@ -240,6 +303,8 @@ pub struct ParsedData {
     pub headings: Vec<Heading>,
     /// Rule definitions for specification traceability
     pub reqs: Vec<ReqDefinition>,
+    /// Source map for rendered elements with `data-sid` attributes.
+    pub source_map: SourceMap,
     /// HTML snippets to inject into the page's `<head>` (e.g., Mermaid.js CDN script)
     pub head_injections: Vec<String>,
     /// Last modification time as Unix timestamp (seconds since epoch)
@@ -453,6 +518,7 @@ pub struct AllRenderedHtml {
         StaticRegistry,
         DataRegistry,
         SourceRegistry,
+        MarkdownRenderSettings,
     ),
     interned(CharSet, crate::queries::DataValuePath,),
     tracked(

--- a/crates/dodeca/src/main.rs
+++ b/crates/dodeca/src/main.rs
@@ -38,8 +38,9 @@ mod vite;
 
 use crate::config::{LinkCheckMode, ResolvedConfig};
 use crate::db::{
-    DataFile, DataRegistry, Database, OutputFile, QueryStats, SassFile, SassRegistry, SourceFile,
-    SourceRegistry, StaticFile, StaticRegistry, TemplateFile, TemplateRegistry,
+    DataFile, DataRegistry, Database, MarkdownRenderSettings, OutputFile, QueryStats, SassFile,
+    SassRegistry, SourceFile, SourceRegistry, StaticFile, StaticRegistry, TemplateFile,
+    TemplateRegistry,
 };
 use crate::queries::build_site;
 use crate::tui::LogEvent;
@@ -370,6 +371,7 @@ async fn async_main(command: Command) -> Result<()> {
                 render_options: render::RenderOptions {
                     livereload: false,
                     dev_mode: false,
+                    source_maps: false,
                 },
                 progress: None,
                 link_check,
@@ -1215,6 +1217,7 @@ pub async fn build(
     // Load picante cache from disk (for font subsetting, image processing, etc.)
     let picante_cache_path = cache_dir.join("dodeca.bin");
     load_picante_cache(&ctx.db, &picante_cache_path).await;
+    MarkdownRenderSettings::set(&*ctx.db, render_options.source_maps)?;
 
     // Phase 1: Load everything into picante
     ctx.load_sources()?;
@@ -2196,6 +2199,7 @@ async fn serve_plain(
     let render_options = render::RenderOptions {
         livereload: true, // Enable live reload in plain mode too
         dev_mode: true,
+        source_maps: true,
     };
 
     // Create the site server
@@ -2590,6 +2594,7 @@ async fn serve_with_tui(
     let render_options = render::RenderOptions {
         livereload: true,
         dev_mode: true,
+        source_maps: true,
     };
 
     // Create the site server - serves directly from picante, no disk I/O

--- a/crates/dodeca/src/main.rs
+++ b/crates/dodeca/src/main.rs
@@ -2199,7 +2199,11 @@ async fn serve_plain(
     };
 
     // Create the site server
-    let server = Arc::new(serve::SiteServer::new(render_options, stable_assets));
+    let server = Arc::new(serve::SiteServer::new(
+        render_options,
+        stable_assets,
+        Some(content_dir.to_path_buf()),
+    ));
     let startup_revision = server.begin_revision("startup");
 
     // Use the requested port (or default to 4000)
@@ -2589,7 +2593,11 @@ async fn serve_with_tui(
     };
 
     // Create the site server - serves directly from picante, no disk I/O
-    let server = Arc::new(serve::SiteServer::new(render_options, stable_assets));
+    let server = Arc::new(serve::SiteServer::new(
+        render_options,
+        stable_assets,
+        Some(content_dir.to_path_buf()),
+    ));
     let startup_revision = server.begin_revision("startup");
 
     // Load cached query results (e.g., processed images) from disk

--- a/crates/dodeca/src/queries.rs
+++ b/crates/dodeca/src/queries.rs
@@ -1,9 +1,10 @@
 use crate::db::{
     AllRenderedHtml, CharSet, CodeExecutionMetadata, CodeExecutionResult, CssOutput, DataRegistry,
-    Db, DependencySourceInfo, ExternalLinkStatus, Heading, ImageVariant, OutputFile, Page,
-    ParsedData, ProcessedImages, RenderedHtml, ReqDefinition, ResolvedDependencyInfo, SassFile,
-    SassRegistry, Section, SiteOutput, SiteTree, SourceFile, SourceRegistry, StaticFile,
-    StaticFileOutput, StaticRegistry, TemplateFile, TemplateRegistry,
+    Db, DependencySourceInfo, ExternalLinkStatus, Heading, ImageVariant, MarkdownRenderSettings,
+    OutputFile, Page, ParsedData, ProcessedImages, RenderedHtml, ReqDefinition,
+    ResolvedDependencyInfo, SassFile, SassRegistry, Section, SiteOutput, SiteTree, SourceFile,
+    SourceKind, SourceMap, SourceMapEntry, SourceRegistry, StaticFile, StaticFileOutput,
+    StaticRegistry, TemplateFile, TemplateRegistry,
 };
 use picante::PicanteResult;
 
@@ -323,25 +324,37 @@ pub async fn parse_file<DB: Db>(db: &DB, source: SourceFile) -> PicanteResult<Pa
     tracing::Span::current().record("path", path.as_str());
     tracing::debug!(path = %path, "Parsing markdown");
 
+    let source_maps = MarkdownRenderSettings::source_maps(db)?.unwrap_or(false);
+
     // Use the markdown cell to parse frontmatter and render markdown
-    let parse_result = match parse_and_render_markdown_cell(path.as_str(), content.as_str()).await {
-        Ok(p) => p,
-        Err(e) => return Ok(Err(e)),
-    };
+    let parse_result =
+        match parse_and_render_markdown_cell(path.as_str(), content.as_str(), source_maps).await {
+            Ok(p) => p,
+            Err(e) => return Ok(Err(e)),
+        };
 
     // Handle the enum result
-    let (frontmatter, html_output, headings_raw, reqs_raw, head_injections) = match parse_result {
-        ParseResult::Success {
-            frontmatter,
-            html,
-            headings,
-            reqs,
-            head_injections,
-        } => (frontmatter, html, headings, reqs, head_injections),
-        ParseResult::Error { message } => {
-            return Ok(Err(MarkdownParseError { message }));
-        }
-    };
+    let (frontmatter, html_output, headings_raw, reqs_raw, head_injections, source_map_raw) =
+        match parse_result {
+            ParseResult::Success {
+                frontmatter,
+                html,
+                headings,
+                reqs,
+                head_injections,
+                source_map,
+            } => (
+                frontmatter,
+                html,
+                headings,
+                reqs,
+                head_injections,
+                source_map,
+            ),
+            ParseResult::Error { message } => {
+                return Ok(Err(MarkdownParseError { message }));
+            }
+        };
 
     // Convert frontmatter from cell type
     let extra: Value = frontmatter.extra.clone();
@@ -364,6 +377,7 @@ pub async fn parse_file<DB: Db>(db: &DB, source: SourceFile) -> PicanteResult<Pa
             anchor_id: r.anchor_id,
         })
         .collect();
+    let source_map = convert_source_map(*source_map_raw);
 
     let body_html = HtmlBody::new(html_output);
 
@@ -383,11 +397,51 @@ pub async fn parse_file<DB: Db>(db: &DB, source: SourceFile) -> PicanteResult<Pa
         is_section,
         headings,
         reqs,
+        source_map,
         head_injections,
         last_updated: last_modified,
         extra,
         template: frontmatter.template,
     }))
+}
+
+fn convert_source_kind(kind: cell_markdown_proto::SourceKind) -> SourceKind {
+    match kind {
+        cell_markdown_proto::SourceKind::Heading => SourceKind::Heading,
+        cell_markdown_proto::SourceKind::Paragraph => SourceKind::Paragraph,
+        cell_markdown_proto::SourceKind::BlockQuote => SourceKind::BlockQuote,
+        cell_markdown_proto::SourceKind::List => SourceKind::List,
+        cell_markdown_proto::SourceKind::ListItem => SourceKind::ListItem,
+        cell_markdown_proto::SourceKind::DefinitionList => SourceKind::DefinitionList,
+        cell_markdown_proto::SourceKind::DefinitionListTitle => SourceKind::DefinitionListTitle,
+        cell_markdown_proto::SourceKind::DefinitionListDefinition => {
+            SourceKind::DefinitionListDefinition
+        }
+        cell_markdown_proto::SourceKind::ThematicBreak => SourceKind::ThematicBreak,
+        cell_markdown_proto::SourceKind::Table => SourceKind::Table,
+        cell_markdown_proto::SourceKind::TableHead => SourceKind::TableHead,
+        cell_markdown_proto::SourceKind::TableRow => SourceKind::TableRow,
+        cell_markdown_proto::SourceKind::TableCell => SourceKind::TableCell,
+        cell_markdown_proto::SourceKind::Image => SourceKind::Image,
+    }
+}
+
+fn convert_source_map(source_map: cell_markdown_proto::SourceMap) -> SourceMap {
+    SourceMap {
+        source_path: source_map.source_path,
+        entries: source_map
+            .entries
+            .into_iter()
+            .map(|entry| SourceMapEntry {
+                id: entry.id,
+                kind: convert_source_kind(entry.kind),
+                line_start: entry.line_start,
+                line_end: entry.line_end,
+                byte_start: entry.byte_start,
+                byte_end: entry.byte_end,
+            })
+            .collect(),
+    }
 }
 
 /// A parse error with its source file path
@@ -511,6 +565,7 @@ pub async fn build_tree<DB: Db>(db: &DB) -> PicanteResult<BuildTreeResult> {
                 body_html: data.body_html.clone(),
                 headings: data.headings.clone(),
                 reqs: data.reqs.clone(),
+                source_map: data.source_map.clone(),
                 head_injections: data.head_injections.clone(),
                 last_updated: data.last_updated,
                 extra: data.extra.clone(),
@@ -528,6 +583,7 @@ pub async fn build_tree<DB: Db>(db: &DB) -> PicanteResult<BuildTreeResult> {
         body_html: HtmlBody::from_static(""),
         headings: Vec::new(),
         reqs: Vec::new(),
+        source_map: SourceMap::default(),
         head_injections: Vec::new(),
         last_updated: 0,
         extra: Value::default(),
@@ -547,6 +603,7 @@ pub async fn build_tree<DB: Db>(db: &DB) -> PicanteResult<BuildTreeResult> {
                 section_route,
                 headings: data.headings.clone(),
                 rules: data.reqs.clone(),
+                source_map: data.source_map.clone(),
                 head_injections: data.head_injections.clone(),
                 last_updated: data.last_updated,
                 extra: data.extra.clone(),

--- a/crates/dodeca/src/render.rs
+++ b/crates/dodeca/src/render.rs
@@ -47,6 +47,8 @@ pub struct RenderOptions {
     pub livereload: bool,
     /// Development mode - show error pages instead of failing
     pub dev_mode: bool,
+    /// Whether markdown rendering should emit `data-sid` attributes and source maps.
+    pub source_maps: bool,
 }
 
 /// CSS for dead link highlighting in dev mode (subtle overline)

--- a/crates/dodeca/src/serve.rs
+++ b/crates/dodeca/src/serve.rs
@@ -4,7 +4,7 @@
 //! This enables instant incremental rebuilds with zero disk I/O.
 
 /// Picante cache version - bump this when making incompatible changes to picante inputs/queries
-pub const PICANTE_CACHE_VERSION: u32 = 5;
+pub const PICANTE_CACHE_VERSION: u32 = 6;
 
 use camino::{Utf8Component, Utf8Path, Utf8PathBuf};
 use eyre::{Result, bail, eyre};
@@ -15,8 +15,9 @@ use tokio::process::Command;
 use tokio::sync::{broadcast, watch};
 
 use crate::db::{
-    DataFile, DataRegistry, Database, DatabaseSnapshot, SassFile, SassRegistry, SourceFile,
-    SourceRegistry, StaticFile, StaticRegistry, TemplateFile, TemplateRegistry,
+    DataFile, DataRegistry, Database, DatabaseSnapshot, MarkdownRenderSettings, SassFile,
+    SassRegistry, SourceFile, SourceRegistry, StaticFile, StaticRegistry, TemplateFile,
+    TemplateRegistry,
 };
 use crate::image::{InputFormat, OutputFormat, add_width_suffix};
 use crate::queries::{build_tree, css_output, process_image, serve_html, static_file_output};
@@ -268,8 +269,12 @@ impl SiteServer {
             started_at: None,
         });
 
+        let db = Arc::new(db);
+        MarkdownRenderSettings::set(&*db, render_options.source_maps)
+            .expect("failed to initialize markdown render settings");
+
         Self {
-            db: Arc::new(db),
+            db,
             livereload_tx,
             render_options,
             source_root,
@@ -284,10 +289,22 @@ impl SiteServer {
     }
 
     pub async fn open_source_in_editor(&self, source_file: &str, line: u32) -> Result<()> {
+        tracing::debug!(
+            source_file,
+            line,
+            "open_source_in_editor: resolving source location"
+        );
+
         let source_root = self
             .source_root
             .as_ref()
             .ok_or_else(|| eyre!("source root is not available in this server mode"))?;
+        tracing::debug!(
+            source_root = %source_root,
+            source_file,
+            "open_source_in_editor: using source root"
+        );
+
         let source_path = Utf8Path::new(source_file);
         if source_path.is_absolute()
             || source_path
@@ -298,26 +315,99 @@ impl SiteServer {
         }
 
         let disk_path = source_root.join(source_path);
+        let disk_path = if disk_path.is_absolute() {
+            disk_path
+        } else {
+            Utf8PathBuf::from_path_buf(std::env::current_dir()?.join(disk_path.as_std_path()))
+                .map_err(|path| eyre!("source path is not UTF-8: {}", path.display()))?
+        };
         let line = line.max(1);
-        let line_arg = format!("{disk_path}:{line}");
-        let editor = std::env::var("DODECA_EDITOR")
-            .or_else(|_| std::env::var("EDITOR"))
-            .unwrap_or_else(|_| "zed".to_string());
-
-        tracing::info!(
-            editor = %editor,
+        tracing::debug!(
             source_file,
             disk_path = %disk_path,
             line,
-            "opening source in editor"
+            "open_source_in_editor: resolved disk path"
         );
 
-        Command::new(&editor)
-            .arg(&line_arg)
-            .spawn()
-            .map_err(|err| eyre!("failed to spawn editor {editor}: {err}"))?;
+        let associated_app = associated_app_for_file(&disk_path).await;
+        tracing::debug!(
+            source_file,
+            disk_path = %disk_path,
+            line,
+            associated_app = ?associated_app,
+            "open_source_in_editor: resolved associated app"
+        );
+
+        if let Some(command) = line_aware_editor_command(associated_app.as_ref(), &disk_path, line)
+        {
+            tracing::info!(
+                editor = command.editor,
+                program = %command.program,
+                args = ?command.args,
+                source_file,
+                disk_path = %disk_path,
+                line,
+                "opening source in associated editor"
+            );
+
+            spawn_source_opener(command.program, command.args, "line-aware editor")?;
+        } else {
+            tracing::debug!(
+                source_file,
+                disk_path = %disk_path,
+                line,
+                associated_app = ?associated_app,
+                "open_source_in_editor: associated app is not a known line-aware editor"
+            );
+            open_plain_source(&disk_path, associated_app.as_ref()).await?;
+        }
 
         Ok(())
+    }
+
+    pub async fn open_source_id_in_editor(&self, route_path: &str, sid: &str) -> Result<()> {
+        tracing::debug!(
+            route = %route_path,
+            sid,
+            "open_source_id_in_editor: resolving source ID"
+        );
+
+        let snapshot = DatabaseSnapshot::from_database(&self.db).await;
+        let site_tree = build_tree(&snapshot)
+            .await?
+            .map_err(|errors| eyre!("source parse errors while resolving source ID: {errors:?}"))?;
+        let route = Route::new(normalize_route(route_path));
+
+        let source_map = if let Some(section) = site_tree.sections.get(&route) {
+            &section.source_map
+        } else if let Some(page) = site_tree.pages.get(&route) {
+            &page.source_map
+        } else {
+            bail!("route is not available for source lookup: {route}");
+        };
+
+        let entry = source_map
+            .get_by_sid(sid)
+            .ok_or_else(|| eyre!("source ID {sid:?} is not available for route {route}"))?;
+        let source_file = source_map
+            .source_path
+            .as_deref()
+            .ok_or_else(|| eyre!("source map for route {route} has no source path"))?
+            .to_string();
+        let line = entry.line_start.max(1);
+
+        tracing::debug!(
+            route = %route,
+            sid,
+            source_file = %source_file,
+            line,
+            kind = ?entry.kind,
+            byte_start = entry.byte_start,
+            byte_end = entry.byte_end,
+            "open_source_id_in_editor: source ID resolved"
+        );
+
+        self.open_source_in_editor(&source_file, line).await
     }
 
     /// Register a browser connection for receiving devtools events.
@@ -764,6 +854,7 @@ impl SiteServer {
                 tracing::warn!("Failed to load cache: {:?}", e);
             }
         }
+        MarkdownRenderSettings::set(&*self.db, self.render_options.source_maps)?;
         Ok(())
     }
 
@@ -1567,6 +1658,307 @@ impl SiteServer {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AssociatedApp {
+    path: Utf8PathBuf,
+    bundle_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct EditorCommand {
+    editor: &'static str,
+    program: String,
+    args: Vec<String>,
+}
+
+#[cfg(target_os = "macos")]
+async fn associated_app_for_file(path: &Utf8Path) -> Option<AssociatedApp> {
+    tracing::debug!(
+        path = %path,
+        "associated_app_for_file: querying LaunchServices"
+    );
+
+    let script = r#"ObjC.import("AppKit");
+function run(argv) {
+    const url = $.NSURL.fileURLWithPath(argv[0]);
+    const app = $.NSWorkspace.sharedWorkspace.URLForApplicationToOpenURL(url);
+    if (!app) return "";
+    const bundle = $.NSBundle.bundleWithURL(app);
+    const bundleId = bundle ? bundle.bundleIdentifier.js : "";
+    return app.path.js + "\n" + bundleId;
+}"#;
+
+    let output = Command::new("/usr/bin/osascript")
+        .args(["-l", "JavaScript", "-e", script, path.as_str()])
+        .output()
+        .await
+        .map_err(|err| {
+            tracing::debug!(
+                path = %path,
+                error = %err,
+                "associated_app_for_file: failed to spawn osascript"
+            );
+            err
+        })
+        .ok()?;
+
+    if !output.status.success() {
+        tracing::warn!(
+            status = %output.status,
+            stderr = %String::from_utf8_lossy(&output.stderr),
+            path = %path,
+            "failed to query associated application"
+        );
+        return None;
+    }
+
+    let stdout = String::from_utf8(output.stdout)
+        .map_err(|err| {
+            tracing::debug!(
+                path = %path,
+                error = %err,
+                "associated_app_for_file: osascript output was not UTF-8"
+            );
+            err
+        })
+        .ok()?;
+    let associated_app = associated_app_from_osascript_output(&stdout);
+    tracing::debug!(
+        path = %path,
+        raw_output = %stdout.trim_end(),
+        associated_app = ?associated_app,
+        "associated_app_for_file: LaunchServices query completed"
+    );
+    associated_app
+}
+
+#[cfg(not(target_os = "macos"))]
+async fn associated_app_for_file(_path: &Utf8Path) -> Option<AssociatedApp> {
+    None
+}
+
+fn associated_app_from_osascript_output(output: &str) -> Option<AssociatedApp> {
+    let mut lines = output.lines();
+    let path = lines.next()?.trim();
+    if path.is_empty() {
+        return None;
+    }
+    let bundle_id = lines
+        .next()
+        .map(str::trim)
+        .filter(|bundle_id| !bundle_id.is_empty())
+        .map(ToOwned::to_owned);
+
+    Some(AssociatedApp {
+        path: Utf8PathBuf::from(path),
+        bundle_id,
+    })
+}
+
+fn line_aware_editor_command(
+    app: Option<&AssociatedApp>,
+    disk_path: &Utf8Path,
+    line: u32,
+) -> Option<EditorCommand> {
+    let Some(app) = app else {
+        tracing::debug!(
+            disk_path = %disk_path,
+            line,
+            "line_aware_editor_command: no associated app"
+        );
+        return None;
+    };
+    let bundle_id = app.bundle_id.as_deref().unwrap_or_default();
+    let app_name = app
+        .path
+        .file_stem()
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let path_line = format!("{disk_path}:{line}");
+    tracing::debug!(
+        app_path = %app.path,
+        bundle_id,
+        app_name,
+        disk_path = %disk_path,
+        line,
+        "line_aware_editor_command: checking associated app"
+    );
+
+    if bundle_id == "dev.zed.Zed" || app_name == "zed" {
+        return Some(EditorCommand {
+            editor: "Zed",
+            program: app_cli_or_name(&app.path, "Contents/MacOS/cli", "zed"),
+            args: vec![path_line],
+        });
+    }
+
+    if bundle_id == "com.microsoft.VSCode"
+        || bundle_id == "com.vscodium"
+        || app_name == "visual studio code"
+        || app_name == "vscodium"
+    {
+        return Some(EditorCommand {
+            editor: "Visual Studio Code",
+            program: app_cli_or_name(&app.path, "Contents/Resources/app/bin/code", "code"),
+            args: vec!["--goto".to_string(), path_line],
+        });
+    }
+
+    if app_name == "cursor" {
+        return Some(EditorCommand {
+            editor: "Cursor",
+            program: app_cli_or_name(&app.path, "Contents/Resources/app/bin/cursor", "cursor"),
+            args: vec!["--goto".to_string(), path_line],
+        });
+    }
+
+    if bundle_id.starts_with("com.sublimetext.") || app_name == "sublime text" {
+        return Some(EditorCommand {
+            editor: "Sublime Text",
+            program: app_cli_or_name(&app.path, "Contents/SharedSupport/bin/subl", "subl"),
+            args: vec![path_line],
+        });
+    }
+
+    if bundle_id == "com.macromates.TextMate" || app_name == "textmate" {
+        return Some(EditorCommand {
+            editor: "TextMate",
+            program: app_cli_or_name(&app.path, "Contents/Resources/mate", "mate"),
+            args: vec!["-l".to_string(), line.to_string(), disk_path.to_string()],
+        });
+    }
+
+    if bundle_id == "com.barebones.bbedit" || app_name == "bbedit" {
+        return Some(EditorCommand {
+            editor: "BBEdit",
+            program: "bbedit".to_string(),
+            args: vec![format!("+{line}"), disk_path.to_string()],
+        });
+    }
+
+    if bundle_id == "org.vim.MacVim" || app_name == "macvim" {
+        return Some(EditorCommand {
+            editor: "MacVim",
+            program: app_cli_or_name(&app.path, "Contents/bin/mvim", "mvim"),
+            args: vec![format!("+{line}"), disk_path.to_string()],
+        });
+    }
+
+    tracing::debug!(
+        app_path = %app.path,
+        bundle_id,
+        app_name,
+        disk_path = %disk_path,
+        line,
+        "line_aware_editor_command: no line-aware mapping for associated app"
+    );
+
+    None
+}
+
+fn app_cli_or_name(app_path: &Utf8Path, cli_relative_path: &str, fallback_name: &str) -> String {
+    let candidate = app_path.join(cli_relative_path);
+    if candidate.exists() {
+        tracing::debug!(
+            app_path = %app_path,
+            cli = %candidate,
+            fallback_name,
+            "app_cli_or_name: using bundled editor CLI"
+        );
+        candidate.to_string()
+    } else {
+        tracing::debug!(
+            app_path = %app_path,
+            cli = %candidate,
+            fallback_name,
+            "app_cli_or_name: bundled editor CLI missing, using PATH fallback"
+        );
+        fallback_name.to_string()
+    }
+}
+
+#[cfg(target_os = "macos")]
+async fn open_plain_source(path: &Utf8Path, app: Option<&AssociatedApp>) -> Result<()> {
+    let mut args = Vec::new();
+    if let Some(bundle_id) = app.and_then(|app| app.bundle_id.as_deref()) {
+        args.extend(["-b".to_string(), bundle_id.to_string()]);
+    } else if let Some(app) = app {
+        args.extend(["-a".to_string(), app.path.to_string()]);
+    }
+    args.push(path.to_string());
+
+    tracing::info!(
+        app = ?app,
+        program = "/usr/bin/open",
+        args = ?args,
+        path = %path,
+        "opening source with associated application"
+    );
+
+    spawn_source_opener("/usr/bin/open".to_string(), args, "associated application")
+}
+
+#[cfg(not(target_os = "macos"))]
+async fn open_plain_source(path: &Utf8Path, _app: Option<&AssociatedApp>) -> Result<()> {
+    tracing::info!(path = %path, "opening source with platform default application");
+    open::that_detached(path.as_str())
+        .map_err(|err| eyre!("failed to open source file {path}: {err}"))?;
+    Ok(())
+}
+
+fn spawn_source_opener(program: String, args: Vec<String>, kind: &'static str) -> Result<()> {
+    let mut child = Command::new(&program)
+        .args(&args)
+        .spawn()
+        .map_err(|err| eyre!("failed to spawn source opener {program}: {err}"))?;
+    let pid = child.id();
+
+    tracing::debug!(
+        program = %program,
+        args = ?args,
+        pid,
+        kind,
+        "spawned source opener"
+    );
+
+    crate::spawn::spawn(async move {
+        match child.wait().await {
+            Ok(status) if status.success() => {
+                tracing::debug!(
+                    program = %program,
+                    args = ?args,
+                    pid,
+                    status = %status,
+                    kind,
+                    "source opener exited successfully"
+                );
+            }
+            Ok(status) => {
+                tracing::warn!(
+                    program = %program,
+                    args = ?args,
+                    pid,
+                    status = %status,
+                    kind,
+                    "source opener exited with non-zero status"
+                );
+            }
+            Err(err) => {
+                tracing::warn!(
+                    program = %program,
+                    args = ?args,
+                    pid,
+                    error = %err,
+                    kind,
+                    "failed to wait for source opener"
+                );
+            }
+        }
+    });
+
+    Ok(())
+}
+
 /// Calculate similarity score between requested path and a route
 fn similarity_score(requested: &str, requested_parts: &[&str], route: &str) -> usize {
     let mut score = 0;
@@ -1776,5 +2168,60 @@ pub fn mime_from_extension(path: &str) -> &'static str {
         // Pagefind-specific extensions
         Some("pf_index") | Some("pf_meta") | Some("pagefind") => "application/octet-stream",
         _ => "application/octet-stream",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_associated_app_output() {
+        let app = associated_app_from_osascript_output(
+            "/Applications/Visual Studio Code.app\ncom.microsoft.VSCode\n",
+        )
+        .expect("app");
+
+        assert_eq!(
+            app,
+            AssociatedApp {
+                path: Utf8PathBuf::from("/Applications/Visual Studio Code.app"),
+                bundle_id: Some("com.microsoft.VSCode".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn vscode_uses_goto_path_line() {
+        let app = AssociatedApp {
+            path: Utf8PathBuf::from("/tmp/NoSuchApp/Visual Studio Code.app"),
+            bundle_id: Some("com.microsoft.VSCode".to_string()),
+        };
+
+        let command =
+            line_aware_editor_command(Some(&app), Utf8Path::new("/site/content/page.md"), 42)
+                .expect("known editor command");
+
+        assert_eq!(
+            command,
+            EditorCommand {
+                editor: "Visual Studio Code",
+                program: "code".to_string(),
+                args: vec!["--goto".to_string(), "/site/content/page.md:42".to_string()],
+            }
+        );
+    }
+
+    #[test]
+    fn unknown_associated_app_falls_back_to_plain_open() {
+        let app = AssociatedApp {
+            path: Utf8PathBuf::from("/Applications/Warp.app"),
+            bundle_id: Some("dev.warp.Warp-Stable".to_string()),
+        };
+
+        assert!(
+            line_aware_editor_command(Some(&app), Utf8Path::new("/site/content/page.md"), 42)
+                .is_none()
+        );
     }
 }

--- a/crates/dodeca/src/serve.rs
+++ b/crates/dodeca/src/serve.rs
@@ -6,10 +6,12 @@
 /// Picante cache version - bump this when making incompatible changes to picante inputs/queries
 pub const PICANTE_CACHE_VERSION: u32 = 5;
 
-use eyre::Result;
+use camino::{Utf8Component, Utf8Path, Utf8PathBuf};
+use eyre::{Result, bail, eyre};
 use hotmeal_server::LiveReloadServer;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, RwLock};
+use tokio::process::Command;
 use tokio::sync::{broadcast, watch};
 
 use crate::db::{
@@ -203,6 +205,8 @@ pub struct SiteServer {
     pub livereload_tx: broadcast::Sender<LiveReloadMsg>,
     /// Render options (dev mode, etc.)
     pub render_options: RenderOptions,
+    /// Content directory used to resolve source paths from rendered HTML.
+    source_root: Option<Utf8PathBuf>,
     /// Live reload server: caches HTML + head injections per route, computes patches
     live_reload: Mutex<LiveReloadServer>,
     /// Cached CSS path (cache-busted) for detecting CSS-only changes
@@ -250,7 +254,11 @@ fn normalize_route(route: &str) -> String {
 }
 
 impl SiteServer {
-    pub fn new(render_options: RenderOptions, stable_assets: Vec<String>) -> Self {
+    pub fn new(
+        render_options: RenderOptions,
+        stable_assets: Vec<String>,
+        source_root: Option<Utf8PathBuf>,
+    ) -> Self {
         let (livereload_tx, _) = broadcast::channel(16);
         let db = Database::new(None);
         let (revision_tx, _) = watch::channel(crate::revision::RevisionState {
@@ -264,6 +272,7 @@ impl SiteServer {
             db: Arc::new(db),
             livereload_tx,
             render_options,
+            source_root,
             live_reload: Mutex::new(LiveReloadServer::new()),
             css_cache: RwLock::new(None),
             stable_assets,
@@ -272,6 +281,43 @@ impl SiteServer {
             revision_tx,
             browsers: std::sync::Mutex::new(BrowserRegistry::default()),
         }
+    }
+
+    pub async fn open_source_in_editor(&self, source_file: &str, line: u32) -> Result<()> {
+        let source_root = self
+            .source_root
+            .as_ref()
+            .ok_or_else(|| eyre!("source root is not available in this server mode"))?;
+        let source_path = Utf8Path::new(source_file);
+        if source_path.is_absolute()
+            || source_path
+                .components()
+                .any(|component| matches!(component, Utf8Component::ParentDir))
+        {
+            bail!("refusing to open source path outside the content directory: {source_file}");
+        }
+
+        let disk_path = source_root.join(source_path);
+        let line = line.max(1);
+        let line_arg = format!("{disk_path}:{line}");
+        let editor = std::env::var("DODECA_EDITOR")
+            .or_else(|_| std::env::var("EDITOR"))
+            .unwrap_or_else(|_| "zed".to_string());
+
+        tracing::info!(
+            editor = %editor,
+            source_file,
+            disk_path = %disk_path,
+            line,
+            "opening source in editor"
+        );
+
+        Command::new(&editor)
+            .arg(&line_arg)
+            .spawn()
+            .map_err(|err| eyre!("failed to spawn editor {editor}: {err}"))?;
+
+        Ok(())
     }
 
     /// Register a browser connection for receiving devtools events.


### PR DESCRIPTION
## Summary
- Add a devtools source-picker overlay that activates with `Alt-E`, highlights rendered source-backed elements, and opens the clicked location in the editor.
- Extend the devtools Vox protocol with an `open_source` RPC and route it through the host server.
- Resolve source paths against the current content root and spawn `zed` by default, with `DODECA_EDITOR`/`EDITOR` overrides.

## Testing
- `cargo check --all-features --all-targets --message-format=short`
- `wasm-pack build --target web crates/dodeca-devtools`
- Local browser smoke test with `ddc serve`: verified `Alt-E` toggles picker mode and clicking a `data-source-file`/`data-source-line` paragraph invokes the editor path at the expected line.