### PR TITLE
Add wiki-style Markdown link resolution

### DIFF
--- a/cells/cell-html-proto/src/lib.rs
+++ b/cells/cell-html-proto/src/lib.rs
@@ -106,6 +106,10 @@ pub struct HtmlProcessInput {
     #[facet(default)]
     pub source_to_route: Option<HashMap<String, String>>,
 
+    /// Wiki link key to route mapping for resolving `dodeca-wiki:` links
+    #[facet(default)]
+    pub wiki_to_route: Option<HashMap<String, String>>,
+
     /// Base route for resolving relative links (e.g., "/guide/intro/")
     #[facet(default)]
     pub base_route: Option<String>,
@@ -135,9 +139,17 @@ pub enum HtmlProcessResult {
         hrefs: Vec<String>,
         /// All id attributes from any element (for fragment validation)
         element_ids: Vec<String>,
+        /// Wiki links that were present but could not be resolved
+        unresolved_wiki_links: Vec<WikiLinkRef>,
     },
     /// Error during processing
     Error { message: String },
+}
+
+#[derive(Debug, Clone, Facet)]
+pub struct WikiLinkRef {
+    pub key: String,
+    pub target: String,
 }
 
 // ============================================================================

--- a/cells/cell-html/src/main.rs
+++ b/cells/cell-html/src/main.rs
@@ -17,7 +17,7 @@ use hotmeal::{Document, LocalName, NodeId, NodeKind, QualName, Stem, StrTendril,
 use cell_host_proto::HostServiceClient;
 use cell_html_proto::{
     CodeExecutionMetadata, HtmlProcessInput, HtmlProcessResult, HtmlProcessor,
-    HtmlProcessorDispatcher, HtmlResult, Injection, ResponsiveImageInfo,
+    HtmlProcessorDispatcher, HtmlResult, Injection, ResponsiveImageInfo, WikiLinkRef,
 };
 use dodeca_cell_runtime::HostHandle;
 
@@ -42,6 +42,7 @@ impl HtmlProcessor for HtmlProcessorImpl {
     async fn process(&self, input: HtmlProcessInput) -> HtmlProcessResult {
         let mut had_dead_links = false;
         let mut had_code_buttons = false;
+        let mut unresolved_wiki_links = Vec::new();
 
         // Phase 1: All sync DOM work (before any await points)
         let (html, hrefs, element_ids) = {
@@ -68,27 +69,32 @@ impl HtmlProcessor for HtmlProcessorImpl {
                 resolve_internal_links_in_doc(&mut doc, source_to_route);
             }
 
-            // 5. Resolve relative links
+            // 5. Resolve wiki links
+            if let Some(wiki_to_route) = &input.wiki_to_route {
+                unresolved_wiki_links = resolve_wiki_links_in_doc(&mut doc, wiki_to_route);
+            }
+
+            // 6. Resolve relative links
             if let Some(base_route) = &input.base_route {
                 resolve_relative_links_in_doc(&mut doc, base_route);
             }
 
-            // 6. Transform images to picture elements
+            // 7. Transform images to picture elements
             if let Some(image_variants) = &input.image_variants {
                 transform_images_in_doc(&mut doc, image_variants);
             }
 
-            // 7. Inject Vite CSS links
+            // 8. Inject Vite CSS links
             if let Some(vite_css_map) = &input.vite_css_map {
                 inject_vite_css_in_doc(&mut doc, vite_css_map);
             }
 
-            // 8. Content injections (on the tree)
+            // 9. Content injections (on the tree)
             for injection in &input.injections {
                 apply_injection(&mut doc, injection);
             }
 
-            // 9. Extract hrefs and element IDs for link checking
+            // 10. Extract hrefs and element IDs for link checking
             let hrefs = extract_hrefs(&doc);
             let element_ids = extract_element_ids(&doc);
 
@@ -141,6 +147,7 @@ impl HtmlProcessor for HtmlProcessorImpl {
             had_code_buttons,
             hrefs,
             element_ids,
+            unresolved_wiki_links,
         }
     }
 
@@ -219,6 +226,14 @@ fn set_attr(doc: &mut Document, node_id: NodeId, attr_name: &str, value: &str) {
         } else {
             elem.attrs.push((qname, Stem::from(value.to_string())));
         }
+    }
+}
+
+/// Remove an attribute from an element
+fn remove_attr(doc: &mut Document, node_id: NodeId, attr_name: &str) {
+    if let NodeKind::Element(elem) = &mut doc.get_mut(node_id).kind {
+        elem.attrs
+            .retain(|(name, _)| name.local.as_ref() != attr_name);
     }
 }
 
@@ -941,6 +956,51 @@ fn resolve_internal_link(href: &str, source_to_route: &HashMap<String, String>) 
 }
 
 // ============================================================================
+// Wiki Link Resolution (dodeca-wiki: links)
+// ============================================================================
+
+const WIKI_LINK_PREFIX: &str = "dodeca-wiki:";
+
+fn resolve_wiki_links_in_doc(
+    doc: &mut Document,
+    wiki_to_route: &HashMap<String, String>,
+) -> Vec<WikiLinkRef> {
+    let mut unresolved = Vec::new();
+
+    if let Some(body_id) = doc.body() {
+        let mut anchors = Vec::new();
+        collect_anchors(doc, body_id, &mut anchors);
+
+        for node_id in anchors {
+            if let Some(href) = get_attr(doc, node_id, "href")
+                && let Some(key) = href.strip_prefix(WIKI_LINK_PREFIX)
+            {
+                if let Some(route) = wiki_to_route.get(key) {
+                    set_attr(doc, node_id, "href", &ensure_trailing_slash(route));
+                    remove_attr(doc, node_id, "data-wiki-target");
+                } else {
+                    unresolved.push(WikiLinkRef {
+                        key: key.to_string(),
+                        target: get_attr(doc, node_id, "data-wiki-target")
+                            .unwrap_or_else(|| key.to_string()),
+                    });
+                }
+            }
+        }
+    }
+
+    unresolved
+}
+
+fn ensure_trailing_slash(route: &str) -> String {
+    if route == "/" || route.ends_with('/') {
+        route.to_string()
+    } else {
+        format!("{route}/")
+    }
+}
+
+// ============================================================================
 // Relative Link Resolution
 // ============================================================================
 
@@ -974,6 +1034,7 @@ fn resolve_relative_link(href: &str, base: &str) -> Option<String> {
         || href.starts_with("https://")
         || href.starts_with('#')
         || href.starts_with("@/")
+        || href.starts_with(WIKI_LINK_PREFIX)
         || href.starts_with("mailto:")
         || href.starts_with("tel:")
         || href.starts_with("javascript:")

--- a/cells/cell-markdown/src/main.rs
+++ b/cells/cell-markdown/src/main.rs
@@ -7,7 +7,7 @@ use cell_markdown_proto::*;
 use dodeca_cell_runtime::HostHandle;
 use marq::{
     AasvgHandler, ArboriumHandler, CompareHandler, InlineCodeHandler, LinkResolver, MermaidHandler,
-    PikruHandler, RenderOptions, TermHandler, render,
+    PikruHandler, RenderOptions, TermHandler, WikiLink, WikiLinkOutput, WikiLinkResolver, render,
 };
 use std::future::Future;
 use std::pin::Pin;
@@ -68,12 +68,30 @@ impl LinkResolver for PassthroughLinkResolver {
     ) -> Pin<Box<dyn Future<Output = Option<String>> + Send + 'a>> {
         Box::pin(async move {
             // Keep @/ links unchanged - dodeca will resolve them with site tree access
-            if link.starts_with("@/") {
+            if link.starts_with("@/") || link.starts_with(WIKI_LINK_PREFIX) {
                 Some(link.to_string())
             } else {
                 // Let marq handle other links (relative .md, external, etc.)
                 None
             }
+        })
+    }
+}
+
+struct DodecaWikiLinkResolver;
+
+impl WikiLinkResolver for DodecaWikiLinkResolver {
+    fn resolve<'a>(
+        &'a self,
+        link: &'a WikiLink,
+        _source_path: Option<&'a str>,
+    ) -> Pin<Box<dyn Future<Output = Option<WikiLinkOutput>> + Send + 'a>> {
+        Box::pin(async move {
+            let key = wiki_link_key(&link.target)?;
+            Some(
+                WikiLinkOutput::new(format!("{WIKI_LINK_PREFIX}{key}"))
+                    .with_attr("data-wiki-target", link.target.as_str()),
+            )
         })
     }
 }
@@ -100,6 +118,7 @@ fn render_options(source_path: &str, source_map: bool) -> RenderOptions {
         .with_source_map(source_map)
         // Pass through @/ links unchanged - dodeca will resolve them with site tree
         .with_link_resolver(PassthroughLinkResolver)
+        .with_wiki_link_resolver(DodecaWikiLinkResolver)
         // Convert rule marker inline code to links
         .with_inline_code_handler(RuleRefHandler)
 }
@@ -195,6 +214,31 @@ impl MarkdownProcessor for MarkdownProcessorImpl {
             MarkdownResult::Error { message } => ParseResult::Error { message },
         }
     }
+}
+
+const WIKI_LINK_PREFIX: &str = "dodeca-wiki:";
+
+fn wiki_link_key(target: &str) -> Option<String> {
+    let mut key = String::new();
+    let mut last_was_dash = true;
+
+    for c in target.chars() {
+        if c.is_alphanumeric() {
+            for lower in c.to_lowercase() {
+                key.push(lower);
+            }
+            last_was_dash = false;
+        } else if !last_was_dash {
+            key.push('-');
+            last_was_dash = true;
+        }
+    }
+
+    while key.ends_with('-') {
+        key.pop();
+    }
+
+    if key.is_empty() { None } else { Some(key) }
 }
 
 // Helper functions to convert marq types to protocol types

--- a/crates/dodeca/src/main.rs
+++ b/crates/dodeca/src/main.rs
@@ -1284,6 +1284,9 @@ pub async fn build(
                         formatted
                     );
                 }
+                queries::SiteError::WikiLinks(wiki_error) => {
+                    eprintln!("{} {}", "✗".red(), wiki_error);
+                }
             }
             std::process::exit(1);
         }

--- a/crates/dodeca/src/queries.rs
+++ b/crates/dodeca/src/queries.rs
@@ -490,6 +490,51 @@ impl std::fmt::Display for RenderError {
 
 impl std::error::Error for RenderError {}
 
+/// Error when resolving wiki-style markdown links.
+#[derive(Debug, Clone, facet::Facet)]
+pub struct WikiLinkError {
+    pub route: Route,
+    pub target: String,
+    pub reason: WikiLinkErrorReason,
+}
+
+#[derive(Debug, Clone, facet::Facet)]
+#[repr(u8)]
+pub enum WikiLinkErrorReason {
+    Missing,
+    Ambiguous { candidates: Vec<String> },
+}
+
+#[derive(Debug, Clone, facet::Facet)]
+pub struct WikiLinkBuildError {
+    pub errors: Vec<WikiLinkError>,
+}
+
+impl std::fmt::Display for WikiLinkBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Failed to resolve {} wiki link(s):", self.errors.len())?;
+        for err in &self.errors {
+            match &err.reason {
+                WikiLinkErrorReason::Missing => {
+                    writeln!(f, "  - {}: [[{}]] target not found", err.route, err.target)?;
+                }
+                WikiLinkErrorReason::Ambiguous { candidates } => {
+                    writeln!(
+                        f,
+                        "  - {}: [[{}]] is ambiguous; candidates: {}",
+                        err.route,
+                        err.target,
+                        candidates.join(", ")
+                    )?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for WikiLinkBuildError {}
+
 /// Errors that can occur during site generation
 #[derive(Debug, Clone, facet::Facet)]
 #[repr(u8)]
@@ -498,6 +543,8 @@ pub enum SiteError {
     Parse(BuildError),
     /// Error during template rendering
     Render(RenderError),
+    /// Error resolving wiki-style markdown links
+    WikiLinks(WikiLinkBuildError),
 }
 
 impl std::fmt::Display for SiteError {
@@ -505,6 +552,7 @@ impl std::fmt::Display for SiteError {
         match self {
             SiteError::Parse(e) => write!(f, "{}", e),
             SiteError::Render(e) => write!(f, "{}", e),
+            SiteError::WikiLinks(e) => write!(f, "{}", e),
         }
     }
 }
@@ -520,6 +568,12 @@ impl From<BuildError> for SiteError {
 impl From<RenderError> for SiteError {
     fn from(e: RenderError) -> Self {
         SiteError::Render(e)
+    }
+}
+
+impl From<WikiLinkBuildError> for SiteError {
+    fn from(e: WikiLinkBuildError) -> Self {
+        SiteError::WikiLinks(e)
     }
 }
 
@@ -638,6 +692,106 @@ pub async fn source_to_route_map<DB: Db>(db: &DB) -> PicanteResult<HashMap<Strin
     }
 
     Ok(map)
+}
+
+#[derive(Debug, Clone, Default)]
+struct WikiLinkIndex {
+    resolved: HashMap<String, String>,
+    ambiguous: HashMap<String, Vec<String>>,
+}
+
+impl WikiLinkIndex {
+    fn build(site_tree: &SiteTree) -> Self {
+        let mut candidates: HashMap<String, Vec<String>> = HashMap::new();
+
+        for section in site_tree.sections.values() {
+            add_wiki_route_candidates(&mut candidates, section.title.as_str(), &section.route);
+            add_wiki_route_candidates(&mut candidates, section.route.as_str(), &section.route);
+            if let Some(slug) = route_leaf_slug(&section.route) {
+                add_wiki_route_candidates(&mut candidates, &slug, &section.route);
+            }
+        }
+
+        for page in site_tree.pages.values() {
+            add_wiki_route_candidates(&mut candidates, page.title.as_str(), &page.route);
+            add_wiki_route_candidates(&mut candidates, page.route.as_str(), &page.route);
+            if let Some(slug) = route_leaf_slug(&page.route) {
+                add_wiki_route_candidates(&mut candidates, &slug, &page.route);
+            }
+        }
+
+        let mut resolved = HashMap::new();
+        let mut ambiguous = HashMap::new();
+        for (key, mut routes) in candidates {
+            routes.sort();
+            routes.dedup();
+            if routes.len() == 1 {
+                resolved.insert(key, routes.remove(0));
+            } else {
+                ambiguous.insert(key, routes);
+            }
+        }
+
+        Self {
+            resolved,
+            ambiguous,
+        }
+    }
+}
+
+fn add_wiki_route_candidates(
+    candidates: &mut HashMap<String, Vec<String>>,
+    target: &str,
+    route: &Route,
+) {
+    if let Some(key) = wiki_link_key(target) {
+        candidates
+            .entry(key)
+            .or_default()
+            .push(wiki_link_route(route));
+    }
+}
+
+fn wiki_link_route(route: &Route) -> String {
+    let route = route.as_str();
+    if route == "/" || route.ends_with('/') {
+        route.to_string()
+    } else {
+        format!("{route}/")
+    }
+}
+
+fn route_leaf_slug(route: &Route) -> Option<String> {
+    route
+        .as_str()
+        .trim_matches('/')
+        .rsplit('/')
+        .next()
+        .filter(|slug| !slug.is_empty())
+        .map(str::to_string)
+}
+
+fn wiki_link_key(target: &str) -> Option<String> {
+    let mut key = String::new();
+    let mut last_was_dash = true;
+
+    for c in target.chars() {
+        if c.is_alphanumeric() {
+            for lower in c.to_lowercase() {
+                key.push(lower);
+            }
+            last_was_dash = false;
+        } else if !last_was_dash {
+            key.push('-');
+            last_was_dash = true;
+        }
+    }
+
+    while key.ends_with('-') {
+        key.pop();
+    }
+
+    if key.is_empty() { None } else { Some(key) }
 }
 
 /// Find the nearest parent section for a route
@@ -1405,7 +1559,7 @@ pub async fn all_rendered_html<DB: Db>(
     db: &DB,
 ) -> PicanteResult<Result<AllRenderedHtml, SiteError>> {
     use crate::render::{render_page_via_cell, render_section_via_cell};
-    use crate::url_rewrite::{resolve_internal_links, resolve_relative_links};
+    use crate::url_rewrite::{resolve_internal_links, resolve_relative_links, resolve_wiki_links};
 
     let site_tree = match build_tree(db).await? {
         Ok(tree) => tree,
@@ -1416,6 +1570,8 @@ pub async fn all_rendered_html<DB: Db>(
     // Get the source-to-route map for internal link resolution
     // This creates dependencies on all source files via parse_file
     let source_route_map = source_to_route_map(db).await?;
+    let wiki_link_index = WikiLinkIndex::build(&site_tree);
+    let mut wiki_link_errors = Vec::new();
 
     let mut pages = HashMap::new();
 
@@ -1433,6 +1589,14 @@ pub async fn all_rendered_html<DB: Db>(
         // Resolve relative links based on section route, then @/ links
         let html = resolve_relative_links(&html, route.as_str()).await;
         let html = resolve_internal_links(&html, &source_route_map).await;
+        let resolved = resolve_wiki_links(&html, &wiki_link_index.resolved).await;
+        collect_wiki_link_errors(
+            &mut wiki_link_errors,
+            route,
+            &resolved.unresolved_wiki_links,
+            &wiki_link_index,
+        );
+        let html = resolved.html;
         pages.insert(route.clone(), html);
     }
 
@@ -1450,10 +1614,48 @@ pub async fn all_rendered_html<DB: Db>(
         // Resolve relative links based on the page's section route, then @/ links
         let html = resolve_relative_links(&html, page.section_route.as_str()).await;
         let html = resolve_internal_links(&html, &source_route_map).await;
+        let resolved = resolve_wiki_links(&html, &wiki_link_index.resolved).await;
+        collect_wiki_link_errors(
+            &mut wiki_link_errors,
+            route,
+            &resolved.unresolved_wiki_links,
+            &wiki_link_index,
+        );
+        let html = resolved.html;
         pages.insert(route.clone(), html);
     }
 
+    if !wiki_link_errors.is_empty() {
+        return Ok(Err(WikiLinkBuildError {
+            errors: wiki_link_errors,
+        }
+        .into()));
+    }
+
     Ok(Ok(AllRenderedHtml { pages }))
+}
+
+fn collect_wiki_link_errors(
+    errors: &mut Vec<WikiLinkError>,
+    source_route: &Route,
+    unresolved_links: &[cell_html_proto::WikiLinkRef],
+    index: &WikiLinkIndex,
+) {
+    for link in unresolved_links {
+        let reason = if let Some(candidates) = index.ambiguous.get(&link.key) {
+            WikiLinkErrorReason::Ambiguous {
+                candidates: candidates.clone(),
+            }
+        } else {
+            WikiLinkErrorReason::Missing
+        };
+
+        errors.push(WikiLinkError {
+            route: source_route.clone(),
+            target: link.target.clone(),
+            reason,
+        });
+    }
 }
 
 /// Extract text content from HTML by stripping tags

--- a/crates/dodeca/src/serve.rs
+++ b/crates/dodeca/src/serve.rs
@@ -1004,6 +1004,14 @@ impl SiteServer {
                             crate::error_pages::render_structured_error_page(&render_error.error);
                         (Some(html), Vec::new(), Some(error_info))
                     }
+                    SiteError::WikiLinks(wiki_error) => (
+                        Some(crate::error_pages::render_generic_error_page(
+                            "Failed to resolve wiki links",
+                            &wiki_error.to_string(),
+                        )),
+                        Vec::new(),
+                        None,
+                    ),
                 }
             }
             Err(e) => {

--- a/crates/dodeca/src/url_rewrite.rs
+++ b/crates/dodeca/src/url_rewrite.rs
@@ -77,6 +77,7 @@ pub async fn process_html(
         injections: vec![],
         minify: None,
         source_to_route: options.source_to_route,
+        wiki_to_route: options.wiki_to_route,
         base_route: options.base_route,
         image_variants: options.image_variants,
         vite_css_map: options.vite_css_map,
@@ -89,11 +90,13 @@ pub async fn process_html(
             had_code_buttons: _,
             hrefs,
             element_ids,
+            unresolved_wiki_links,
         }) => Ok(HtmlProcessOutput {
             html,
             had_dead_links,
             hrefs,
             element_ids,
+            unresolved_wiki_links,
         }),
         Ok(cell_html_proto::HtmlProcessResult::Error { message }) => {
             Err(eyre::eyre!("HTML processing error: {}", message))
@@ -111,6 +114,8 @@ pub struct HtmlProcessOptions {
     pub known_routes: Option<HashSet<String>>,
     /// Source path to route mapping for @/ links
     pub source_to_route: Option<HashMap<String, String>>,
+    /// Wiki link key to route mapping for dodeca-wiki: links
+    pub wiki_to_route: Option<HashMap<String, String>>,
     /// Base route for relative link resolution
     pub base_route: Option<String>,
     /// Image variants for picture element transformation
@@ -130,6 +135,8 @@ pub struct HtmlProcessOutput {
     pub hrefs: Vec<String>,
     /// All id attributes from elements
     pub element_ids: Vec<String>,
+    /// Wiki link keys that were present but could not be resolved
+    pub unresolved_wiki_links: Vec<cell_html_proto::WikiLinkRef>,
 }
 
 /// Mark dead internal links in HTML using the cell
@@ -173,6 +180,36 @@ pub async fn resolve_internal_links(
             html.to_string()
         }
     }
+}
+
+/// Resolve `dodeca-wiki:` prefixed links in HTML using a wiki key to route mapping.
+pub async fn resolve_wiki_links(
+    html: &str,
+    wiki_to_route: &HashMap<String, String>,
+) -> WikiLinkResolution {
+    let options = HtmlProcessOptions {
+        wiki_to_route: Some(wiki_to_route.clone()),
+        ..Default::default()
+    };
+
+    match process_html(html, options).await {
+        Ok(output) => WikiLinkResolution {
+            html: output.html,
+            unresolved_wiki_links: output.unresolved_wiki_links,
+        },
+        Err(e) => {
+            tracing::warn!("Wiki link resolution failed: {}", e);
+            WikiLinkResolution {
+                html: html.to_string(),
+                unresolved_wiki_links: Vec::new(),
+            }
+        }
+    }
+}
+
+pub struct WikiLinkResolution {
+    pub html: String,
+    pub unresolved_wiki_links: Vec<cell_html_proto::WikiLinkRef>,
 }
 
 /// Resolve relative links in HTML by joining with base route.

--- a/crates/integration-tests/src/main.rs
+++ b/crates/integration-tests/src/main.rs
@@ -663,6 +663,24 @@ fn collect_tests() -> Vec<Test> {
             func: internal_links::relative_md_links_resolved,
             ignored: false,
         },
+        Test {
+            name: "wiki_links_resolved",
+            module: "internal_links",
+            func: internal_links::wiki_links_resolved,
+            ignored: false,
+        },
+        Test {
+            name: "missing_wiki_link_fails_build",
+            module: "internal_links",
+            func: internal_links::missing_wiki_link_fails_build,
+            ignored: false,
+        },
+        Test {
+            name: "ambiguous_wiki_link_fails_build",
+            module: "internal_links",
+            func: internal_links::ambiguous_wiki_link_fails_build,
+            ignored: false,
+        },
         // sass tests
         Test {
             name: "no_scss_builds_successfully",

--- a/crates/integration-tests/src/tests/internal_links.rs
+++ b/crates/integration-tests/src/tests/internal_links.rs
@@ -168,3 +168,120 @@ This is page B.
         hrefs
     );
 }
+
+/// Test that wiki-style links resolve through the site title/slug index
+pub fn wiki_links_resolved() {
+    let site = TestSite::with_files(
+        "sample-site",
+        &[
+            (
+                "content/company.md",
+                r#"---
+title: Company
+---
+
+The company page.
+"#,
+            ),
+            (
+                "content/repository-map.md",
+                r#"---
+title: Repository Map
+---
+
+The repository map.
+"#,
+            ),
+            (
+                "content/wiki-link-test.md",
+                r#"---
+title: Wiki Link Test
+---
+
+See [[Company]] and [[Repository Map|repo map]].
+"#,
+            ),
+        ],
+    );
+
+    let html = site.get("/wiki-link-test/");
+    html.assert_ok();
+
+    let tendril = StrTendril::from(html.text());
+    let doc = hotmeal::parse(&tendril);
+    let hrefs = extract_hrefs(&doc);
+
+    assert!(
+        !hrefs.iter().any(|h| h.starts_with("dodeca-wiki:")),
+        "Wiki hrefs should be resolved before serving, found: {:?}",
+        hrefs
+    );
+    assert!(
+        hrefs.iter().any(|h| h == "/company/"),
+        "Should have wiki link to /company/, found: {:?}",
+        hrefs
+    );
+    assert!(
+        hrefs.iter().any(|h| h == "/repository-map/"),
+        "Should have wiki link to /repository-map/, found: {:?}",
+        hrefs
+    );
+    html.assert_contains(">repo map</a>");
+}
+
+/// Test that missing wiki links fail the build with a link diagnostic
+pub fn missing_wiki_link_fails_build() {
+    let site = InlineSite::new(&[(
+        "index.md",
+        r#"---
+title: Home
+---
+
+See [[Missing Page]].
+"#,
+    )]);
+
+    site.build()
+        .assert_failure()
+        .assert_output_contains("Failed to resolve 1 wiki link")
+        .assert_output_contains("[[Missing Page]] target not found");
+}
+
+/// Test that ambiguous wiki links fail the build with candidate routes
+pub fn ambiguous_wiki_link_fails_build() {
+    let site = InlineSite::new(&[
+        (
+            "index.md",
+            r#"---
+title: Home
+---
+
+See [[Shared]].
+"#,
+        ),
+        (
+            "a.md",
+            r#"---
+title: Shared
+---
+
+A.
+"#,
+        ),
+        (
+            "b.md",
+            r#"---
+title: Shared
+---
+
+B.
+"#,
+        ),
+    ]);
+
+    site.build()
+        .assert_failure()
+        .assert_output_contains("[[Shared]] is ambiguous")
+        .assert_output_contains("/a/")
+        .assert_output_contains("/b/");
+}


### PR DESCRIPTION
## Summary
- Added native support for `[[Page]]` and `[[Page|label]]` wiki links in Markdown.
- Resolved wiki links through the Dodeca HTML pipeline using page titles, full routes, and leaf slugs.
- Surfaced missing and ambiguous targets as build errors, while preserving existing `@/...md` and relative link behavior.
- Added integration coverage for resolved, missing, and ambiguous wiki links.

## Testing
- `cargo fmt`
- `cargo xtask wasm`
- `cargo check -p cell-markdown -p cell-html -p dodeca -p integration-tests`
- `cargo xtask integration internal_links`