### PR TITLE
Reuse section context for get_section

### DIFF
--- a/crates/dodeca/src/render.rs
+++ b/crates/dodeca/src/render.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 pub use crate::error_pages::RENDER_ERROR_MARKER;
 
 /// Get base_url from global config, defaulting to "/" for local development
-fn get_base_url() -> String {
+pub(crate) fn get_base_url() -> String {
     crate::config::global_config()
         .map(|c| c.base_url.clone())
         .unwrap_or_else(|| "/".to_string())
@@ -722,11 +722,6 @@ fn heading_to_value(h: &Heading, children: Vec<Value>) -> Value {
     map.into()
 }
 
-/// Convert headings to a hierarchical TOC Value (Zola-style nested structure)
-pub fn headings_to_toc(headings: &[Heading]) -> Value {
-    build_toc_tree(headings)
-}
-
 /// Convert headings to hierarchical Value list for template context
 fn headings_to_value(headings: &[Heading]) -> Value {
     build_toc_tree(headings)
@@ -1010,16 +1005,6 @@ pub fn path_to_route(path: &str) -> Route {
         Route::new(p)
     } else {
         Route::new(format!("/{p}"))
-    }
-}
-
-/// Convert a route like "/learn/" back to a path like "learn/_index.md"
-pub fn route_to_path(route: &str) -> String {
-    let r = route.trim_matches('/');
-    if r.is_empty() {
-        "_index.md".to_string()
-    } else {
-        format!("{r}/_index.md")
     }
 }
 

--- a/crates/dodeca/src/template_host.rs
+++ b/crates/dodeca/src/template_host.rs
@@ -17,13 +17,13 @@ use cell_gingembre_proto::{
     CallFunctionResult, ContextId, KeysAtResult, LoadTemplateResult, ResolveDataResult,
     TemplateHost,
 };
-use facet_value::{DestructuredRef, VArray, VObject, VString, Value};
+use facet_value::{DestructuredRef, Value};
 use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::db::{Database, SiteTree};
 use crate::queries::{DataValuePath, data_keys_at_path, resolve_data_value};
-use crate::render::{headings_to_toc, path_to_route, route_to_path};
+use crate::render::{get_base_url, path_to_route, section_to_value};
 
 /// Convert a Value to a string representation (for template function args)
 fn value_to_string(value: &Value) -> String {
@@ -319,61 +319,8 @@ impl TemplateHost for TemplateHostImpl {
                 let route = path_to_route(&path);
 
                 let result = if let Some(section) = context.site_tree.sections.get(&route) {
-                    let mut section_map = VObject::new();
-                    section_map.insert(VString::from("title"), Value::from(section.title.as_str()));
-                    section_map.insert(
-                        VString::from("permalink"),
-                        Value::from(section.route.as_str()),
-                    );
-                    section_map.insert(VString::from("path"), Value::from(path.as_str()));
-                    section_map.insert(
-                        VString::from("content"),
-                        Value::from(section.body_html.as_str()),
-                    );
-                    section_map.insert(VString::from("toc"), headings_to_toc(&section.headings));
-                    section_map.insert(VString::from("extra"), section.extra.clone());
-
-                    let section_pages: Vec<Value> = context
-                        .site_tree
-                        .pages
-                        .values()
-                        .filter(|p| p.section_route == section.route)
-                        .map(|p| {
-                            let mut page_map = VObject::new();
-                            page_map.insert(VString::from("title"), Value::from(p.title.as_str()));
-                            page_map
-                                .insert(VString::from("permalink"), Value::from(p.route.as_str()));
-                            page_map.insert(
-                                VString::from("path"),
-                                Value::from(route_to_path(p.route.as_str()).as_str()),
-                            );
-                            page_map.insert(VString::from("weight"), Value::from(p.weight as i64));
-                            page_map.insert(VString::from("toc"), headings_to_toc(&p.headings));
-                            page_map.into()
-                        })
-                        .collect();
-                    section_map.insert(VString::from("pages"), VArray::from_iter(section_pages));
-
-                    let subsections: Vec<Value> = context
-                        .site_tree
-                        .sections
-                        .values()
-                        .filter(|s| {
-                            s.route != section.route
-                                && s.route.as_str().starts_with(section.route.as_str())
-                                && s.route.as_str()[section.route.as_str().len()..]
-                                    .trim_matches('/')
-                                    .chars()
-                                    .filter(|c| *c == '/')
-                                    .count()
-                                    == 0
-                        })
-                        .map(|s| Value::from(route_to_path(s.route.as_str()).as_str()))
-                        .collect();
-                    section_map
-                        .insert(VString::from("subsections"), VArray::from_iter(subsections));
-
-                    section_map.into()
+                    let base_url = get_base_url();
+                    section_to_value(section, &context.site_tree, &base_url)
                 } else {
                     Value::NULL
                 };

--- a/crates/integration-tests/src/main.rs
+++ b/crates/integration-tests/src/main.rs
@@ -588,6 +588,12 @@ fn collect_tests() -> Vec<Test> {
             ignored: false,
         },
         Test {
+            name: "get_section_returns_weighted_subsection_objects",
+            module: "section_pages",
+            func: section_pages::get_section_returns_weighted_subsection_objects,
+            ignored: false,
+        },
+        Test {
             name: "removing_sibling_page_updates_page_section_pages_list",
             module: "section_pages",
             func: section_pages::removing_sibling_page_updates_page_section_pages_list,

--- a/crates/integration-tests/src/tests/section_pages.rs
+++ b/crates/integration-tests/src/tests/section_pages.rs
@@ -52,6 +52,57 @@ fn collect_link_titles(doc: &Document, node_id: NodeId, titles: &mut Vec<String>
     }
 }
 
+fn collect_link_details(
+    doc: &Document,
+    node_id: NodeId,
+    links: &mut Vec<(String, Option<String>, Option<String>)>,
+) {
+    let node = doc.get(node_id);
+    if let NodeKind::Element(elem) = &node.kind
+        && elem.tag.as_ref() == "a"
+    {
+        let mut text = String::new();
+        collect_text(doc, node_id, &mut text);
+        let title = text.trim();
+        if !title.is_empty() {
+            let href = elem
+                .attrs
+                .iter()
+                .find(|(name, _)| name.local.as_ref() == "href")
+                .map(|(_, value)| value.to_string());
+            let data_path = elem
+                .attrs
+                .iter()
+                .find(|(name, _)| name.local.as_ref() == "data-path")
+                .map(|(_, value)| value.to_string());
+            links.push((title.to_string(), href, data_path));
+        }
+    }
+
+    for child_id in doc.children(node_id) {
+        collect_link_details(doc, child_id, links);
+    }
+}
+
+fn extract_nav_links(
+    html: &str,
+    nav_id: &str,
+    context: &str,
+) -> Vec<(String, Option<String>, Option<String>)> {
+    let tendril = StrTendril::from(html);
+    let doc = hotmeal::parse(&tendril);
+
+    let Some(nav_node) = find_nav_by_id(&doc, doc.root, nav_id) else {
+        tracing::debug!("{}: No {} nav found in HTML", context, nav_id);
+        return Vec::new();
+    };
+
+    let mut links = Vec::new();
+    collect_link_details(&doc, nav_node, &mut links);
+    tracing::debug!("{}: Found subsection links: {:?}", context, links);
+    links
+}
+
 fn nav_exists(html: &str, nav_id: &str) -> bool {
     let tendril = StrTendril::from(html);
     let doc = hotmeal::parse(&tendril);
@@ -404,6 +455,101 @@ pub fn removing_page_updates_via_get_section_macro() {
         "Expected Advanced to be removed from macro section list, got {:?}",
         titles
     );
+}
+
+pub fn get_section_returns_weighted_subsection_objects() {
+    let site = TestSite::with_files(
+        "sample-site",
+        &[
+            (
+                "content/guide/alpha/_index.md",
+                r#"+++
+title = "Alpha"
+weight = 20
++++
+
+# Alpha
+"#,
+            ),
+            (
+                "content/guide/alpha/first.md",
+                r#"+++
+title = "Alpha Page"
++++
+
+# Alpha Page
+"#,
+            ),
+            (
+                "content/guide/beta/_index.md",
+                r#"+++
+title = "Beta"
+weight = 10
++++
+
+# Beta
+"#,
+            ),
+            (
+                "templates/section.html",
+                r#"<!DOCTYPE html>
+<html>
+<head>
+  <title>{{ section.title }}</title>
+</head>
+<body>
+  <h1>{{ section.title }}</h1>
+  {% set sec = get_section(path=section.path) %}
+  <nav id="subsection-list">
+    {% for sub in sec.subsections %}
+      <a href="{{ sub.permalink }}" data-path="{{ sub.path }}">{{ sub.title }}</a>
+      {% for page in sub.pages %}
+        <span class="subsection-page">{{ page.title }}</span>
+      {% endfor %}
+    {% endfor %}
+  </nav>
+</body>
+</html>
+"#,
+            ),
+        ],
+    );
+
+    let html = site.wait_until(
+        "get_section subsections to render as weighted objects",
+        Duration::from_secs(2),
+        || {
+            let html = site.get("/guide/");
+            if html.status != 200 || !nav_exists(&html.body, "subsection-list") {
+                return None;
+            }
+
+            let titles = extract_nav_titles(&html.body, "subsection-list", "Subsection objects");
+            if titles == ["Beta", "Alpha"] {
+                Some(html)
+            } else {
+                None
+            }
+        },
+    );
+
+    let links = extract_nav_links(&html.body, "subsection-list", "Subsection link details");
+    assert_eq!(
+        links,
+        vec![
+            (
+                "Beta".to_string(),
+                Some("/guide/beta".to_string()),
+                Some("/guide/beta".to_string())
+            ),
+            (
+                "Alpha".to_string(),
+                Some("/guide/alpha".to_string()),
+                Some("/guide/alpha".to_string())
+            ),
+        ]
+    );
+    html.assert_contains("Alpha Page");
 }
 
 pub fn removing_sibling_page_updates_page_section_pages_list() {


### PR DESCRIPTION
## Summary
- Reapply the useful part of #252 on current main: make `get_section(...)` use the same section serializer as normal section rendering.
- Remove the reduced hand-built section/page/subsection shape from `template_host`.
- Add a focused integration case for weighted subsection objects returned through `get_section`.

## Testing
- `cargo check -p dodeca -p integration-tests`
- `cargo xtask integration --no-build get_section_returns_weighted_subsection_objects`
- `cargo xtask integration --no-build section_pages` passed 5/6 tests, including the two existing `get_section` macro tests and the new subsection-object test; the final unrelated `removing_sibling_page_updates_page_section_pages_list` case hung in harness startup `GET /` before its test body, and also hung when run alone.
- Pre-push hook passed: clippy, docs, build tests, and run tests.

Supersedes the implementation approach from #252.
