### PR TITLE
Fix Windows build: static CRT for vendored libjxl and .exe binary suffix

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,5 @@
+target-applies-to-host = false
+
 [alias]
 xtask = "run --package xtask --"
 
@@ -7,6 +9,12 @@ git-fetch-with-cli = true
 # Enable getrandom for WASM targets
 [target.wasm32-unknown-unknown]
 rustflags = ["--cfg", "getrandom_backend=\"wasm_js\""]
+
+# jpegxl-src hardcodes the static CRT (/MT) for libjxl on Windows MSVC
+# (CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded), so the rest of the build must
+# also use the static CRT or linking fails with LNK2038 RuntimeLibrary mismatch.
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]
 
 # # Unstable features (requires nightly or cargo +nightly)
 # [unstable]

--- a/crates/dodeca-sandbox/src/lib.rs
+++ b/crates/dodeca-sandbox/src/lib.rs
@@ -54,7 +54,9 @@ pub use unsupported::{Command, ExitStatus, Output, Sandbox, Stdio};
 /// Result type for sandbox operations.
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[cfg(test)]
+// These tests exercise a real sandbox; on platforms with only the `unsupported`
+// stub (e.g. Windows) `Sandbox::new` always errors, so there is nothing to test.
+#[cfg(all(test, any(target_os = "linux", target_os = "macos")))]
 mod tests {
     use super::*;
 

--- a/crates/dodeca-sandbox/src/unsupported.rs
+++ b/crates/dodeca-sandbox/src/unsupported.rs
@@ -3,7 +3,6 @@
 //! This module provides stub implementations that return errors on platforms
 //! where sandboxing is not supported.
 
-use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
@@ -26,7 +25,7 @@ impl Sandbox {
     /// Create a command to run in this sandbox.
     pub fn command(&self, program: impl AsRef<Path>) -> Command {
         Command {
-            program: program.as_ref().to_path_buf(),
+            _program: program.as_ref().to_path_buf(),
         }
     }
 }
@@ -44,7 +43,7 @@ pub enum Stdio {
 
 /// A command (not supported on this platform).
 pub struct Command {
-    program: PathBuf,
+    _program: PathBuf,
 }
 
 impl Command {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -338,9 +338,11 @@ fn install_dev() -> bool {
 
     let release_dir = PathBuf::from("target/release");
 
-    // Copy ddc binary (remove first to avoid "text file busy" on Linux)
-    let ddc_src = release_dir.join("ddc");
-    let ddc_dst = cargo_bin.join("ddc");
+    // Copy ddc binary (remove first to avoid "text file busy" on Linux).
+    // EXE_SUFFIX is ".exe" on Windows and empty elsewhere.
+    let ddc_name = format!("ddc{}", env::consts::EXE_SUFFIX);
+    let ddc_src = release_dir.join(&ddc_name);
+    let ddc_dst = cargo_bin.join(&ddc_name);
     let _ = fs::remove_file(&ddc_dst);
     if let Err(e) = fs::copy(&ddc_src, &ddc_dst) {
         eprintln!("Failed to copy ddc: {e}");
@@ -504,7 +506,7 @@ fn run_integration_tests(no_build: bool, extra_args: &[&str]) -> bool {
         eprintln!("Using DODECA_BIN from environment: {}", env_bin);
         PathBuf::from(env_bin)
     } else {
-        let ddc_bin = target_dir.join("ddc");
+        let ddc_bin = target_dir.join(format!("ddc{}", env::consts::EXE_SUFFIX));
         if !ddc_bin.exists() {
             eprintln!(
                 "{}: ddc binary not found at {}",


### PR DESCRIPTION
jpegxl-src hardcodes CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded (static /MT) for libjxl on Windows MSVC, so the rest of the build must also use the static CRT or linking fails with LNK2038 RuntimeLibrary mismatches against dynamically-linked C deps (woff2/woofwoof, libwebp, etc.). Enable crt-static for x86_64-pc-windows-msvc.

Also resolve the ddc binary name with std::env::consts::EXE_SUFFIX in the install and integration-test paths so they find ddc.exe on Windows instead of a bare ddc.